### PR TITLE
Feature/notification mode deprecate

### DIFF
--- a/spesifikasjoner/afpant/afpant-1-0-0.md
+++ b/spesifikasjoner/afpant/afpant-1-0-0.md
@@ -73,7 +73,7 @@ Wildcard "&ast;" kan erstattes med en vilkårlig streng (må være et gyldig fil
 - SignedMortgageDeedProcessedMessage.statusDescription må være angitt på norsk.
 
 ## Avlesningskvittering
-Etter fullført prosessering av en forsendelse, vil mottakende systemleverandør returnerer en avlesningskvittering via Altinn Formidlingstjeneste til avsender-bank. Denne vil innehollde en strukturert Ack/nack-melding som kan brukes av avsender-bank til å oppdatere state/workflow i eget (bank)fagsystem.
+Etter fullført prosessering av en forsendelse, vil mottakende systemleverandør returnerer en avlesningskvittering via Altinn Formidlingstjeneste til avsender-bank. Denne vil inneholde en strukturert Ack/nack-melding som kan brukes av avsender-bank til å oppdatere state/workflow i eget (bank)fagsystem.
 
 ## Altinn Formidlingstjeneste: Manifest
 Altinn ServiceEngine Broker støtter at avsender angir egendefinerte key/value pairs i Manifest.PropertyList (Manifest-objektet angis i ServiceEngine BrokerServiceInitiation.Manifest property). 

--- a/spesifikasjoner/afpant/afpant-1-0-0.md
+++ b/spesifikasjoner/afpant/afpant-1-0-0.md
@@ -49,7 +49,7 @@ Deretter produseres det et **ZIP**-arkiv som inneholder følgende filer:
 
 **NB**: Dersom mer enn 1 pantedokument fra samme lånesak skal tinglyses på samme matrikkelenhet må dette sendes som to separate forsendelser. For eksempel i tilfeller hvor det er to debitorer (låntakere) som ikke er ektefeller/samboere/registrerte partnere som skal ha likestilt prioritet, men separate pantedokumenter.
 
-Avsender-bank angir manifest metadata-keys ved initiering av Altinn-forsendelsen som indikerer om avsender-bank ønsker avlesingskvittering (maskinell og/eller pr email), og hvorvidt følgebrevet er inkludert i ZIP eller om det sendes out-of-band (f.eks via fax eller mail direkte til megler/oppgjør).
+Avsender-bank angir manifest metadata-keys ved initiering av Altinn-forsendelsen som indikerer meldingstype, informasjon om avsender (navn, epost, tlfnr), og hvorvidt følgebrevet er inkludert i ZIP eller om det sendes out-of-band (f.eks via fax eller mail direkte til megler/oppgjør).
 Mottaker (systemleverandør) pakker ut ZIP og parser SDO for å trekke ut nøkkeldata (kreditor, debitor(er), matrikkelenhet(er)) som brukes for å rute forsendelsen til korrekt oppdrag hos korrekt megler/oppgjørsforetak.
 
 ## Validering og ruting hos mottakende system
@@ -73,13 +73,12 @@ Wildcard "&ast;" kan erstattes med en vilkårlig streng (må være et gyldig fil
 - SignedMortgageDeedProcessedMessage.statusDescription må være angitt på norsk.
 
 ## Avlesningskvittering
-Avsender-bank kan angi hvorvidt mottakende fagsystem skal returnere en avlesningskvittering, og man kan velge følgende metoder:
-* Avsender-bank angir i manifest metadata keys (senderName/senderEmail/senderPhone) kontaktinformasjonen til kontaktperson i bank og key (notificationMode) om de ønsker emailvarsling fra mottakende fagsystem ved suksessfull ruting og/eller feil.
-* Avsender-bank angir i manifest metadata key (notificationMode) enum verdi «AltinnNotification». Dette betyr at avsender-bank ønsker en strukturert ack/nack-melding fra mottakende fagsystem ved behandling. Ack/nack-meldingen kan da brukes av avsender-bank til å oppdatere state/workflow i eget (bank)fagsystem.
-* Avsender-bank angir i manifest metadata key (coverLetter) enum verdi som tilsier hvorvidt følgebrevet ligger som PDF/XML inne i ZIP eller om det sendes til megler/oppgjør på annet vis. Eventuell PDF/XML er ment til manuell behandling av oppgjørsansvarlig på lik linje med dagens papirbaserte følgebrev. 
+Etter fullført prosessering av en forsendelse, vil mottakende systemleverandør returnerer en avlesningskvittering via Altinn Formidlingstjeneste til avsender-bank. Denne vil innehollde en strukturert Ack/nack-melding som kan brukes av avsender-bank til å oppdatere state/workflow i eget (bank)fagsystem.
 
 ## Altinn Formidlingstjeneste: Manifest
 Altinn ServiceEngine Broker støtter at avsender angir egendefinerte key/value pairs i Manifest.PropertyList (Manifest-objektet angis i ServiceEngine BrokerServiceInitiation.Manifest property). 
+
+Avsender-bank angir i manifest metadata key 'coverLetter' en enum verdi som tilsier hvorvidt følgebrevet ligger som PDF/XML inne i ZIP eller om det sendes til megler/oppgjør på annet vis. Eventuell PDF/XML er ment til manuell behandling av oppgjørsansvarlig på lik linje med dagens papirbaserte følgebrev.
 
 Ved bruk av ServiceEngine webservices vil Altinn Formidlingstjenester automatisk legge til en fil med navn "manifest.xml" i ZIP-filen som avsender tilknytter forsendelsen.
 
@@ -106,12 +105,6 @@ Ved bruk av ServiceEngine webservices vil Altinn Formidlingstjenester automatisk
 			<td><p>Denne kan være en av følgende:</p><ul><li>SignedMortgageDeed</li></ul></td>
 		</tr>
 		<tr>
-			<td><p>notificationMode</p></td>
-			<td><p>String[] (enum[])</p></td>
-			<td><p>No</p></td>
-			<td><p>Kommaseparert liste over alle notifications avsender ønsker. Følgende strenger kan være verdi i array:</p><ul><li>EmailNotificationWhenRoutedSuccessfully</li><li>EmailNotificationWhenFailed</li><li>AltinnNotification</li></ul><p>Hvis du f.eks. har «EmailNotificationWhenFailed» og «AltinnNotification» skal mottaker sende epost hvis behandling av pantedokumentet feiler og uansett sende en ack/nack gjennom Altinn.</p></td>
-		</tr>
-		<tr>
 			<td><p>senderName</p></td>
 			<td><p>String</p></td>
 			<td><p>No</p></td>
@@ -121,7 +114,7 @@ Ved bruk av ServiceEngine webservices vil Altinn Formidlingstjenester automatisk
 			<td><p>senderEmail</p></td>
 			<td><p>String</p></td>
 			<td><p>No</p></td>
-			<td><p>Required hvis notificationMode EmailNotificationWhenRoutedSuccessfully eller EmailNotificationWhenFailed er angitt.<br> Email til avsender</p></td>
+			<td><p>Email til avsender</p></td>
 		</tr>
 		<tr>
 			<td><p>senderPhone</p></td>


### PR DESCRIPTION
Vi fjerner notificationMode propertyen i manifest, og lar ack/nack meldinger alltid gå tilbake til avsender via Altinn. Vi kan ikke se for oss noe scenario der avsender ikke trenger å få en ack/nack melding, eller der epost er nødvendig/foretrukket. Dersom det er ønskelig å beholde støtten for ack/nack via epost får vi vurdere å re-introdusere dette.