### PR TITLE
Ta vekk krav om teller og nevner

### DIFF
--- a/spesifikasjoner/afpant/afpant-model/xsd/dsve-1.0.0.xsd
+++ b/spesifikasjoner/afpant/afpant-model/xsd/dsve-1.0.0.xsd
@@ -511,8 +511,8 @@
   </xs:complexType>
 
   <xs:complexType name="Broek">
-    <xs:attribute name="teller" type="xs:long" use="required"/>
-    <xs:attribute name="nevner" type="xs:long" use="required"/>
+    <xs:attribute name="teller" type="xs:long"/>
+    <xs:attribute name="nevner" type="xs:long"/>
   </xs:complexType>
 
   <xs:complexType name="Registerenheter">


### PR DESCRIPTION
Det er kommet inn krav om teller og nevner i brøk. For å være bakoverkompatible, må dette reverseres, eller klarer ingen å motta intensjonsmeldinger fra Nordea.

```
      <andel/>
```
Nordea sender en tom andel (uten teller og nevner) i dag, så den meldingen vil ikke validere og parses hvis skjemaet har krav til teller og nevner.