### PR TITLE
<> tolkes som html og <unik identifikator> vises ikke i nettleseren

### DIFF
--- a/spesifikasjoner/afpant/afpant-kjoepekontrakt/kjoepekontrakt-teknisk-beskrivelse.md
+++ b/spesifikasjoner/afpant/afpant-kjoepekontrakt/kjoepekontrakt-teknisk-beskrivelse.md
@@ -81,8 +81,8 @@ Den signert kjøpekontrakten er enten en PDF eller en SDO.
 
 **Krav til filnavn i ZIP-arkiv:** 
 * Filnavnet til meldingen KjoepekontraktSvarFraMegler må følge konvensjonen: _kjoepekontraktsvarframegler*.xml_ . (navnet til meldingen i lowercase)
-* Filnavnet til en evt. signert kjøpekontrakt skal følge konvensjonen: _signert_kjoepekontrakt_<unik identifikator>.(pdf|sdo)_.
-* Filnavn kjøpekontrakt i zip må være unikt i forsendelsen og være likt `vedlegg.navn` for tilhørende kjøpekontraktsdata. (_<unik identifikator>_) 
+* Filnavnet til en evt. signert kjøpekontrakt skal følge konvensjonen: _signert_kjoepekontrakt*.(pdf|sdo)_.
+* Filnavn kjøpekontrakt i zip må være unikt i forsendelsen og være likt `vedlegg.navn` for tilhørende kjøpekontraktsdata. 
 
 
 ## Manifest

--- a/spesifikasjoner/afpant/afpant-kjoepekontrakt/kjoepekontrakt-teknisk-beskrivelse.md
+++ b/spesifikasjoner/afpant/afpant-kjoepekontrakt/kjoepekontrakt-teknisk-beskrivelse.md
@@ -74,16 +74,17 @@ Håndtering av meldingstype [KjoepekontraktforespoerselFraBank](#meldingstype-kj
 
 ## Payload
 
-Dersom status i manifestet er _RutetSuksessfullt_ (se beskrivelse av manifest under) skal ZIP-arkivet inneholde en XML xml-fil 
-med `KjoepekontraktSvarFraMegler` som root element definert av [definert skjema.](../afpant-model/xsd/dsve-1.0.0.xsd)
+Dersom status i manifestet er _RutetSuksessfullt_ (se beskrivelse av manifest under) skal ZIP-arkivet inneholde en xml-fil 
+med `kjoepekontraktsvarFraMegler` som root element definert av [definert skjema.](../afpant-model/xsd/dsve-1.0.0.xsd)
 Dersom kjøpekontrakten er signert skal ZIP-arkiv også innholde den signert kjøpekontrakten være med som en egen fil.
 Den signert kjøpekontrakten er enten en PDF eller en SDO.
+
+Ved negativt resultat lasted et tomt zip-arkiv opp. Manifest key "status" og "statusDescription" må avleses for årsak.
 
 **Krav til filnavn i ZIP-arkiv:** 
 * Filnavnet til meldingen KjoepekontraktSvarFraMegler må følge konvensjonen: _kjoepekontraktsvarframegler*.xml_ . (navnet til meldingen i lowercase)
 * Filnavnet til en evt. signert kjøpekontrakt skal følge konvensjonen: _signert_kjoepekontrakt*.(pdf|sdo)_.
 * Filnavn kjøpekontrakt i zip må være unikt i forsendelsen og være likt `vedlegg.navn` for tilhørende kjøpekontraktsdata. 
-
 
 ## Manifest
 (BrokerServiceInitiation.Manifest.PropertyList)
@@ -93,17 +94,6 @@ Den signert kjøpekontrakten er enten en PDF eller en SDO.
 |messageType|String|Ja|KjoepekontraktsvarFraMegler|
 |status|String (enum)|Ja|Denne kan være en av følgende statuser: <ol><li>**RutetSuksessfullt**<br/>Status 'RutetSuksessfullt' er å anse som ACK (positive acknowledgement) hvor . Øvrige statuser er å anse som NACK (negative acknowledgement).</li><li>**UgyldigKjøper**<br/>Megler har ikke funnet oppgjør/oppdrag for angitt(e) kjøper(e)</li> <li>**Avvist** (sendt til et organisasjonsnummer som ikke lenger har et aktivt kundeforhold hos leverandøren - feil config i Altinn AFPANT, eller ugyldig forsendelse).</li></ol>Kun status '**RutetSuksessfullt**' er å anse som ACK (positive acknowledgement) hvor . Øvrige statuser er å anse som NACK (negative acknowledgement).|
 |statusDescription|String|Nei|Inneholder en utfyllende, menneskelig-lesbar beskrivelse om hvorfor en forsendelse ble NACK-et.|
-
-## Payload
-En ZIP-fil som inneholder en XML med requestdata ihht. [definert skjema.](../afpant-model/xsd/dsve-1.0.0.xsd)
-
-### Positiv resultat (ACK)
-- En xml-fil med **kjoepekontraktsvarFraMegler** som root element og som er i henhold til [definert skjema](../afpant-model/xsd/dsve-1.0.0.xsd).
-
-Merk at signert kjøpekontrakt skal finnes som en egen fil i ZIP-arkivet dersom metdata inneholder et vedlegg som matcher _signert_kjoepekontrakt*.(pdf|sdo)_.
-
-### Negativt resultat (NACK)
-- Tom payload returneres (ZIP arkiv med dummy innhold). Manifest key "status" og "statusDescription" må avleses for årsak.
 
 # Meldingstype: KjoepekontraktFraMegler
 Megler sender uoppfordret til bank eller ved ved signifikante endringer.


### PR DESCRIPTION
<unik identifikator> blir ikke vist i nettleseren og er derfor bare synlig hvis en leser markdown-filen "rått". Endret til * som er brukt andre steder på samme siden.

Stusset litt på formuleringen "Dersom filformat er sdo må innholdet være en pdf" som står i samme filen. Er det riktig? 