### PR TITLE
AvbruttSamhandling

### DIFF
--- a/spesifikasjoner/afpant/afpant-intensjon/intensjon.md
+++ b/spesifikasjoner/afpant/afpant-intensjon/intensjon.md
@@ -21,7 +21,7 @@ Alle som implementerer støtte for mottak av "_IntensjonFraBank_" eller mottak a
 
 Mottakere av meldingstypen "_IntensjonFraBank_" må benytte avsenders saksnummer (_IntensjonFraBank.Avsender.Referanse_) i all videre kommunikasjon til avsenderbank.
 
-Intensjonssendringer stoppes dersom forutsetningene ikke lengre er tilstede. Dette uavhengig av om det er implementert støtte for [AvbruttSamhandling](#AvbruttSamhandling).
+Intensjonssendringer stoppes dersom forutsetningene ikke lengre er tilstede. Dette uavhengig av om det er implementert støtte for [AvbruttSamhandling](#meldingstype-avbruttsamhandling)
 
 ## Validering og ruting
 ### Ruting (meglersystem)

--- a/spesifikasjoner/afpant/afpant-intensjon/intensjon.md
+++ b/spesifikasjoner/afpant/afpant-intensjon/intensjon.md
@@ -21,6 +21,8 @@ Alle som implementerer støtte for mottak av "_IntensjonFraBank_" eller mottak a
 
 Mottakere av meldingstypen "_IntensjonFraBank_" må benytte avsenders saksnummer (_IntensjonFraBank.Avsender.Referanse_) i all videre kommunikasjon til avsenderbank.
 
+Intensjonssendringer stoppes dersom forutsetningene ikke lengre er tilstede. Dette uavhengig av om det er implementert støtte for [AvbruttSamhandling](#AvbruttSamhandling).
+
 ## Validering og ruting
 ### Ruting (meglersystem)
 - mottakende systemleverandør søker blant alle sine kunders matrikkelenhet(er)

--- a/spesifikasjoner/afpant/afpant-intensjon/intensjon.md
+++ b/spesifikasjoner/afpant/afpant-intensjon/intensjon.md
@@ -106,3 +106,22 @@ En ZIP-fil som inneholder en XML med requestdata ihht. [definert skjema.](../afp
 ##### Modell
 ![model intensjonsendring](examples/intensjonsendring-model.png "Modell intensjonsendring")
 <hr/>
+
+
+## Meldingstype: AvbruttSamhandling
+Sendes når forutseningen for samhandling ikke lenger er tilstede. 
+Dette kan for eksempel gjelde hvis kjøper i oppdraget er endret slik at opprinnelig kunde ikke lenger inngår i oppdraget og GDPR tilsier at man ikke lenger kan motta informasjon fra megler.
+Det er opp til megler/megler sitt system å avgjøre når denne meldingen skal sendes.
+Det er opp til mottaker å avgjøre hva som skjer i systmet i etterkant av denne meldingen.
+
+Meldingtypen "AvbruttSamhandling" gir ikke ACK/NACK fra mottaker.
+
+I AKELDO kan meldingstypen "AvbruttSamhandling" finnes både på en aktørs 'sendeliste' og 'mottaksliste'.
+Det lages ikke en avbrutt melding per "hovedmelding". Ved mottak skal man anta at all samhandling avsluttes for eksempel både kjøpekontrak og intensjon.
+
+### Manifest
+(BrokerServiceInitiation.Manifest.PropertyList)
+
+|Manifest key|Type|Obligatorisk| Beskrivelse        |
+|--- |--- |--- |--------------------|
+|messageType|String|Ja| AvbruttSamhandling |

--- a/spesifikasjoner/afpant/afpant-kjoepekontrakt/kjoepekontrakt-loesningsbeskrivelse.md
+++ b/spesifikasjoner/afpant/afpant-kjoepekontrakt/kjoepekontrakt-loesningsbeskrivelse.md
@@ -78,6 +78,30 @@ Hvilke felter som skal trigge en melding til banken om at det har skjedd en endr
 
 Meldingstype: [kjoepekontraktEndringFraMegler](./kjoepekontrakt-teknisk-beskrivelse.md#kjoepekontraktendringframegler-ved-endring) 
 
+## Avbrutt samhandling
+
+Sendes når forutseningen for samhandling ikke lenger er tilstede. Dette kan for eksempel gjelde hvis kjøper i oppdraget er endret slik at opprinnelig kunde ikke lenger inngår i oppdraget og GDPR tilsier at man ikke lenger kan motta informasjon fra megler.
+Det er opp til mottaker å avgjøre hva som skjer i systmet i etterkant av denne meldingen.
+
+Meldingtypen "AvbruttSamhandling" gir ikke ACK/NACK fra mottaker.
+
+I AKELDO kan meldingstypen "AvbruttSamhandling" finnes både på en aktørs 'sendeliste' og 'mottaksliste'. 
+Det lages ikke en avbrutt melding per "hovedmelding". Ved mottak skal man anta at all samhandling avsluttes for eksempel både kjøpekontrak og intensjon.
+
+### Manifest
+(BrokerServiceInitiation.Manifest.PropertyList)
+
+|Manifest key|Type|Obligatorisk| Beskrivelse        |
+|--- |--- |--- |--------------------|
+|messageType|String|Ja| AvbruttSamhandling |
+
+Meldingstype: [AvbruttSamhandling](./kjoepekontrakt-teknisk-beskrivelse.md#AvbruttSamhandling)
+
+
+## Uoppfordret
+
+Meldingstype: [kjoepekontraktUoppfordretFraMegler](./kjoepekontrakt-teknisk-beskrivelse.md#kjoepekontraktuoppfordretframegler-sendes-uoppfordret)
+
 # Alternative flyter
 
 ## Kjøpekontrakten er ikke signert
@@ -125,8 +149,6 @@ I tilfeller hvor megler har informasjon om banken som har verifisert finansierin
 til bank når denne er signert, uten å først ha mottatt en forespørsel fra banken. 
 Dette innebærer at megler kan sende kjøpekontrakt og strukturerte data ved hjelp av en pushmelding til banken.
 I slike tilfeller vil megler da ikke kunne fylle ut bankens referanse i meldingen!
-
-Meldingstype: [kjoepekontraktUoppfordretFraMegler](./kjoepekontrakt-teknisk-beskrivelse.md#kjoepekontraktuoppfordretframegler-sendes-uoppfordret) 
 
 
 

--- a/spesifikasjoner/afpant/afpant-kjoepekontrakt/kjoepekontrakt-teknisk-beskrivelse.md
+++ b/spesifikasjoner/afpant/afpant-kjoepekontrakt/kjoepekontrakt-teknisk-beskrivelse.md
@@ -18,12 +18,13 @@ må også støtte mottak av [KjoepekontraktFraMegler](#meldingstype-kjoepekontra
 
 # Meldingstyper
 ## Oversikt over meldingstyper for kjøpekontrakt
-| Navn | Beskrivelse | Payload/vedlagt fil | 
-|------|------|----|
-| [KjoepekontraktforespoerselFraBank](#meldingstype-kjoepekontraktforespoerselfrabank) | Bank forespør kjøpekontrakt fra megler | XSD: KjoepekontraktforespoerselFraBank | 
-| [KjoepekontraktSvarFraMegler](#meldingstype-kjoepekontraktsvarframegler)  | Meglers svar på Kjøpekontraktforespørsel fra bank | XSD: KjoepekontraktSvarFraMegler |
-| [KjoepekontraktEndringFraMegler](#kjoepekontraktendringframegler-ved-endring) | Megler sender endringer og tillegg i kjøpekontrakten uoppfordret, til bank som allerede har forespurt kjøpekontrakten. Denne meldingen skal ikke besvares. | XSD: KjoepekontraktFraMegler |
-|[KjoepekontraktUoppfordretFraMegler](#kjoepekontraktuoppfordretframegler-sendes-uoppfordret)|Megler sender kjøpekontrakt uoppfordret til bank som ikke har forespurt kjøpekontrakt. Denne meldingen skal ikke besvares.|XSD: KjoepekontraktFraMegler|
+| Navn                                                                                         | Beskrivelse                                                                                                                                                | Payload/vedlagt fil                    | 
+|----------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------|
+| [KjoepekontraktforespoerselFraBank](#meldingstype-kjoepekontraktforespoerselfrabank)         | Bank forespør kjøpekontrakt fra megler                                                                                                                     | XSD: KjoepekontraktforespoerselFraBank | 
+| [KjoepekontraktSvarFraMegler](#meldingstype-kjoepekontraktsvarframegler)                     | Meglers svar på Kjøpekontraktforespørsel fra bank                                                                                                          | XSD: KjoepekontraktSvarFraMegler       |
+| [KjoepekontraktEndringFraMegler](#kjoepekontraktendringframegler-ved-endring)                | Megler sender endringer og tillegg i kjøpekontrakten uoppfordret, til bank som allerede har forespurt kjøpekontrakten. Denne meldingen skal ikke besvares. | XSD: KjoepekontraktFraMegler           |
+| [AvbruttSamhandling](#AvbruttSamhandling)                             | Megler sender til bank hvis det er endringer som gjør at videre samhandling ikke er aktuelt.                                                               | XSD: AvbruttSamhandling                |
+| [KjoepekontraktUoppfordretFraMegler](#kjoepekontraktuoppfordretframegler-sendes-uoppfordret) | Megler sender kjøpekontrakt uoppfordret til bank som ikke har forespurt kjøpekontrakt. Denne meldingen skal ikke besvares.                                 | XSD: KjoepekontraktFraMegler           |
 
 # Meldingstype: KjoepekontraktforespoerselFraBank
 Bank forespør kjøpekontrakt fra megler
@@ -133,6 +134,14 @@ Meglers systemleverandør slutter å sende oppdateringer via kjoepekontraktEndri
 
 
 _Denne meldingen skal ikke besvares._ 
+
+### AvbruttSamhandling
+Sendes når forutseningen for samhandling ikke lenger er tilstede. 
+Dette kan for eksempel gjelde hvis kjøper i oppdraget er endret slik at opprinnelig kunde ikke lenger inngår i oppdraget og GDPR tilsier at man ikke lenger kan motta informasjon fra megler.
+Det er opp til megler/megler sitt system å avgjøre når denne meldingen skal sendes.
+Det er opp til mottaker å avgjøre hva som skjer i systmet i etterkant av denne meldingen.
+
+_Denne meldingen skal ikke besvares._
 
 ## Validering og ruting(banksystem)
 Mottakende systemleverandør søker blant lånesaker hvor saksnummer matcher `kjoepekontrakt.bank.referanse` dersom den er angitt.

--- a/spesifikasjoner/afpant/afpant-kjoepekontrakt/kjoepekontrakt-teknisk-beskrivelse.md
+++ b/spesifikasjoner/afpant/afpant-kjoepekontrakt/kjoepekontrakt-teknisk-beskrivelse.md
@@ -16,6 +16,8 @@ Hvilke endringer/felter som krever at megler sender på nytt er angitt med _hake
 Alle banker som implementerer støtte for mottak av [KjoepekontraktSvarFraMegler](#meldingstype-kjoepekontraktsvarframegler) 
 må også støtte mottak av [KjoepekontraktFraMegler](#meldingstype-kjoepekontraktframegler).
 
+Kjøpekontraktsendringer stoppes dersom forutsetningene ikke lengre er tilstede. Dette uavhengig av om det er implementert støtte for [AvbruttSamhandling](#AvbruttSamhandling).
+
 # Meldingstyper
 ## Oversikt over meldingstyper for kjøpekontrakt
 | Navn                                                                                         | Beskrivelse                                                                                                                                                | Payload/vedlagt fil                    | 

--- a/spesifikasjoner/afpant/afpant-model/xsd/dsve.xsd
+++ b/spesifikasjoner/afpant/afpant-model/xsd/dsve.xsd
@@ -14,6 +14,7 @@
   <xs:element name="intensjonsendring" type="Intensjonsendring"/>
   <xs:element name="gjennomfoertetinglysing" type="GjennomfoertEtinglysing"/>
   <xs:element name="oppnaaddprioritetok" type="OppnaaddPrioritetOk"/>
+  <xs:element name="avbruttsamhandling" type="AvbruttSamhandling"/>
 
   <xs:complexType name="KjoepekontraktforespoerselFraBank">
     <xs:annotation>
@@ -788,4 +789,28 @@
       <xs:element name="kjoeper" type="Aktoer" minOccurs="0" maxOccurs="unbounded"/>
     </xs:sequence>
   </xs:complexType>
+
+  <xs:complexType name="AvbruttSamhandling">
+    <xs:annotation>
+      <xs:documentation>
+        Avbrutt samhandling er en meldings om sendes for tidligere etablert sammhandling hvor forutsettningen for samhandling ikke lenger er tilstede.
+        Typisk kan dette sendes hvor man ikke lenger vil sende intensjonsendring eller kjoepekontraktEndringFraMegler.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element minOccurs="1" maxOccurs="1" name="mottaker" type="Mottaker"/>
+      <xs:element minOccurs="1" maxOccurs="1" name="avsender" type="Avsender"/>
+      <xs:element minOccurs="1" maxOccurs="1" name="begrunnelse" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            En menneskelig forstårlig tekst som kan forklare hvorfor samhandling er avsluttet
+            Eksempel: "Kjøper har trukket seg fra kjøpet", "Forkjøpsrett er benyttet", "Kjøper har ikke godkjent finansiering"
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+
+
 </xs:schema>


### PR DESCRIPTION
Smalt sammen ett raskt forslag til meldingstypen "AvbruttSamhandling"

Tanken er at denne er felles for alle, og kan per i dag sendes ved intensjon og kjøpekontrakt. Den kan benyttes for andre eksisterende og fremtidige meldingstyper hvor dette er aktuelt. Den er dokumentert under kjøpekontrakt og intensjon siden det er ved disse to typene jeg ser behovet nå.

Den avslutter all samhandling og man sender ikke to meldinger hvis man har både kjøpekontrakt og intensjon i en sak.
Meldingen er super enkel og inneholder egentlig bare avsender og mottaker slik at man kan få overført referansene man trenger for å mappe i systemet ved mottak.