### PR TITLE
PascalCase keys in SignedMortgageDeedProcessedMessage

### DIFF
--- a/spesifikasjoner/afpant/afpant-kjøperspantedokument/afpant-kjøperspantedokument.md
+++ b/spesifikasjoner/afpant/afpant-kjøperspantedokument/afpant-kjøperspantedokument.md
@@ -136,22 +136,22 @@ Ved bruk av ServiceEngine webservices vil Altinn Formidlingstjenester automatisk
 			<td><p><strong>Beskrivelse</strong></p></td>
 		</tr>
 		<tr>
-			<td><p>messageType</p></td>
+			<td><p>MessageType</p></td>
 			<td><p>String</p></td>
 			<td><p>Denne kan være en av følgende:</p><ul><li>SignedMortgageDeedProcessed</li></ul></td>
 		</tr>
 		<tr>
-			<td><p>status</p></td>
+			<td><p>Status</p></td>
 			<td><p>String (enum)</p></td>
 			<td>Denne kan være en av følgende statuser:	<ul><li>RoutedSuccessfully</li><li>UnknownCadastre (ukjent matrikkelenhet)</li><li>DebitorMismatch (fant matrikkelenhet, men antall kjøpere eller navn/id på kjøpere matcher ikke debitorer i pantedokumentet)</li><li>Rejected (sendt til et organisasjonsnummer som ikke lenger har et aktivt kundeforhold hos leverandøren - feil config i Altinn AFPANT, eller ugyldig forsendelse)</li></ul> Kun status 'RoutedSuccessfully' er å anse som ACK (positive acknowledgement). Øvrige statuser er å anse som NACK (negative acknowledgement).</td>
 		</tr>
 		<tr>
-			<td><p>statusDescription</p></td>
+			<td><p>StatusDescription</p></td>
 			<td><p>String</p></td>
 			<td><p>Inneholder en utfyllende human-readable beskrivelse om hvorfor en forsendelse ble NACK'et.</td>
 		</tr>
 		<tr>
-			<td><p>externalSystemId</p></td>
+			<td><p>ExternalSystemId</p></td>
 			<td><p>String</p></td>
 			<td><p>Optional: ID/oppdragsnummer/key i eksternt meglersystem/fagsystem.</p></td>
 		</tr>


### PR DESCRIPTION
Etter oppfordring fra @ropatambitadotcom legger jeg inn en fiks på casingen på keys for `SignedMortgageDeedProcessedMessage`. Vi fulgte speccen men bankene fikk aldri meldingene våre, da vi sendte nøklene i camelCase og ikke PascalCase. https://github.com/bitsnorge/e-tinglysing-afpant/pull/33 hadde et forslag om å endre til PascalCase, men iom. at den aldri ble merget kunne vi ikke følge speccen her.

Tenker også dette burde dokumenteres i en XSD (spesifikasjoner/afpant/afpant-model/xsd/dsve.xsd?), men det kan jeg evt. gjøre i en ny PR.

Og ellers, hei! Jeg er utvikler i Propware, og vi har utviklet en integrasjon mot Tinglysing hos Kartverket, samt prøvd å koble oss på Afpant-systemet (med varierende hell 😅). Håper vi kan ha en tettere dialog rundt Afpant og bli med på de tekniske møtene etter sommeren.

Mvh Jon Espen Kvisler