### PR TITLE
Fixing anvarlig typo in examples and docs

### DIFF
--- a/spesifikasjoner/afpant/afpant-model/examples/intensjonsendring-example.xml
+++ b/spesifikasjoner/afpant/afpant-model/examples/intensjonsendring-example.xml
@@ -7,11 +7,11 @@
 	</avsender>
 	<megler id="991111123">
 		<foretaksnavn>DSVE Megling AS</foretaksnavn>
-		<anvarligMegler>
+		<ansvarligMegler>
 			<navn>Megler Ansvarlig</navn>
 			<epost>meglernavn@dsve-megling.no</epost>
 			<telefonDirekte>99999999</telefonDirekte>
-		</anvarligMegler>
+		</ansvarligMegler>
 		<referanse>17-19-9999</referanse>
 		<oppgjoersavdeling id="983570658">
 			<foretaksnavn>Weboppgjør AS</foretaksnavn>

--- a/spesifikasjoner/afpant/afpant-model/examples/intensjonssvarframegler-example.xml
+++ b/spesifikasjoner/afpant/afpant-model/examples/intensjonssvarframegler-example.xml
@@ -7,11 +7,11 @@
 	</avsender>
 	<megler id="991111123">
 		<foretaksnavn>DSVE Megling AS</foretaksnavn>
-		<anvarligMegler>
+		<ansvarligMegler>
 			<navn>Megler Ansvarlig</navn>
 			<epost>meglernavn@dsve-megling.no</epost>
 			<telefonDirekte>99999999</telefonDirekte>
-		</anvarligMegler>
+		</ansvarligMegler>
 		<referanse>17-19-9999</referanse>
 		<oppgjoersavdeling id="983570658">
 			<foretaksnavn>Weboppgjør AS</foretaksnavn>

--- a/spesifikasjoner/afpant/afpant-model/examples/restgjeldsforespoersel-example.xml
+++ b/spesifikasjoner/afpant/afpant-model/examples/restgjeldsforespoersel-example.xml
@@ -10,12 +10,12 @@
 	</mottaker>
 	<megler id="945811714">
 		<foretaksnavn>DNB Eiendom</foretaksnavn>
-		<anvarligMegler>
+		<ansvarligMegler>
 			<navn>Ole Olsen</navn>
 			<epost>ole@megler.no</epost>
 			<telefonDirekte>99223452</telefonDirekte>
 			<telefon>55300455</telefon>
-		</anvarligMegler>
+		</ansvarligMegler>
 		<referanse>OPGNR-123</referanse>
 		<oppgjoersavdeling id="912345678">
 			<foretaksnavn>Megleroppjør AS</foretaksnavn>

--- a/spesifikasjoner/afpant/afpant-model/examples/saldoforespoersel-request-example.xml
+++ b/spesifikasjoner/afpant/afpant-model/examples/saldoforespoersel-request-example.xml
@@ -4,12 +4,12 @@
 
 	<megler id="945811714">
 		<foretaksnavn>DNB Eiendom</foretaksnavn>
-		<anvarligMegler>
+		<ansvarligMegler>
 			<navn>Ole Olsen</navn>
 			<epost>ole@megler.no</epost>
 			<telefonDirekte>99223452</telefonDirekte>
 			<telefon>55300455</telefon>
-		</anvarligMegler>
+		</ansvarligMegler>
 		<referanse>OPGNR-123</referanse>
 		<oppgjoersavdeling id="912345678">
 			<foretaksnavn>Megleroppjør AS</foretaksnavn>

--- a/spesifikasjoner/afpant/arkiv-fremtidigfunksjonalitet/afpant-pantefrafall/afpant-pantefrafall.md
+++ b/spesifikasjoner/afpant/arkiv-fremtidigfunksjonalitet/afpant-pantefrafall/afpant-pantefrafall.md
@@ -2,7 +2,7 @@
 
 **Mottaker**: Bank/finansieringselskap firmanavn og org.nummer
 
-**Avsender**: Meglerforetak, orgnummer, Anvarlig megler, mobilnummer og mailadresse.
+**Avsender**: Meglerforetak, orgnummer, Ansvarlig megler, mobilnummer og mailadresse.
 
 **Returneres til meglers oppgjørsavdeling**:
 

--- a/spesifikasjoner/afpant/arkiv-fremtidigfunksjonalitet/afpant-pantefrafall/afpant-restgjeldsoppgave/afpant-restgjeldsoppgave.md
+++ b/spesifikasjoner/afpant/arkiv-fremtidigfunksjonalitet/afpant-pantefrafall/afpant-restgjeldsoppgave/afpant-restgjeldsoppgave.md
@@ -2,7 +2,7 @@
 
 **Mottaker**: Bank/finansieringselskap firmanavn og org.nummer
 
-**Avsender**: Meglerforetak, orgnummer, Anvarlig megler, mobilnummer og mailadresse.
+**Avsender**: Meglerforetak, orgnummer, Ansvarlig megler, mobilnummer og mailadresse.
 
 **Returneres til meglers oppgjørsavdeling**:
 

--- a/spesifikasjoner/afpant/arkiv-fremtidigfunksjonalitet/afpant-pantefrafall/afpant-saldoforespørsel/afpant-saldoforespørsel.md
+++ b/spesifikasjoner/afpant/arkiv-fremtidigfunksjonalitet/afpant-pantefrafall/afpant-saldoforespørsel/afpant-saldoforespørsel.md
@@ -2,7 +2,7 @@
 
 **Mottaker**: Bank/finansieringselskap firmanavn og org.nummer
 
-**Avsender**: Meglerforetak, orgnummer, Anvarlig megler, mobilnummer og mailadresse.
+**Avsender**: Meglerforetak, orgnummer, Ansvarlig megler, mobilnummer og mailadresse.
 
 **Returneres til meglers oppgjørsavdeling**:
 


### PR DESCRIPTION
`anvarligMegler` used in several examples, also similar typo in some comments.