### PR TITLE
Restgjeld xslt

### DIFF
--- a/.github/workflows/release-and-publish.yaml
+++ b/.github/workflows/release-and-publish.yaml
@@ -1,0 +1,106 @@
+name: release-and-publish
+
+on:
+  # Triggers the workflow on push to master i.e when somone merges a pull request on master
+  push:
+    branches: [ "master" ]
+jobs:
+  # This workflow has two jobs, 1 creates a new release, the second pushes the release to the CDN
+  release:
+    name: Release new version
+    # Outputs the value of the check if doc release, the next job will not run if this fails
+    outputs:
+      releaseType: ${{ steps.release.outputs.releaseType}}
+      newVersionNumber: ${{ steps.newVersionNumber.outputs.newVersionNumber}}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Checks what kind of release this is based on the commit message, doc changes does not trigger a new release
+      # We can assume that the commit message follows the naming conventions here because they have been sanitized during the PR
+      - name: Check release type
+        id: release
+        run: .github/workflows/scripts/shared/determineReleaseType.ps1
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          repoPath: ${{ github.repository }}
+          gitHubHost: ${{ github.server_url }}
+          mergeCommitMessage: ${{ github.event.head_commit.message }}
+
+      #Does not run if the merge was a doc change
+      - name: Determine new version number
+        id: newVersionNumber
+        if: steps.release.outputs.releaseType != 'doc'
+        run: .github/workflows/scripts/release-and-publish/findNewVersion.ps1
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RepositoryURI: ${{ github.repository }}
+          RepositoryHost: ${{ github.server_url }}
+          ReleaseType: ${{ steps.release.outputs.releaseType }}
+
+      #Does not run if the merge was a doc change
+      #Must have a tag before creating a release
+      - name: Create new tag
+        if: steps.release.outputs.releaseType != 'doc'
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git tag -a "${{ steps.newVersionNumber.outputs.newVersionNumber}}" -m "Release v${{ steps.newVersionNumber.outputs.newVersionNumber}}"
+          git push origin
+
+      #Does not run if the merge was a doc change
+      - name: Create release
+        if: steps.release.outputs.releaseType != 'doc'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create ${{ steps.newVersionNumber.outputs.newVersionNumber}} \
+          --repo ${{ github.repositoryUrl }} \
+          --title 'v${{ steps.newVersionNumber.outputs.newVersionNumber}}' \
+          --generate-notes \
+          --notes "# New release version: ${{ steps.newVersionNumber.outputs.newVersionNumber}} *This is an automated release triggered by the merge of a pull request in the repository: ${{ github.repositoryUrl }}. Please see the Pull request that caused this release for further details.*"
+
+  cdn-push:
+    name: Push new release to Azure CDN
+    # Does not run if the release is a doc release
+    needs: [release]
+    if: needs.release.outputs.releaseType != 'doc'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Azure login
+        uses: azure/login@v2
+        with:
+          creds: '{ "clientSecret": "${{ secrets.AZURE_CDN_SERVICE_PRINCIPAL_SECRET }}", "subscriptionId": "${{ secrets.AZURE_CDN_SUBSCRIPTION_ID }}", "tenantId": "${{ secrets.AZURE_CDN_TENANT_ID }}", "clientId": "${{ secrets.AZURE_CDN_SERVICE_PRINCIPAL_CLIENTID }}"}'
+
+      - name: Set up Azure CLI
+        run: |
+          curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+
+      - name: Prepare files for upload
+        run: .github/workflows/scripts/release-and-publish/uploadAfpantFilesToAzure.ps1
+        shell: pwsh
+
+      - name: Upload release to CDN
+        shell: pwsh
+        env:
+          azureStorageBlobContainerName: ${{ secrets.AZURE_STORAGE_BLOB_CONTAINER_NAME }}
+          azureStorageAccountName: ${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}
+          newVersionNumber: ${{ needs.release.outputs.newVersionNumber }}
+        run: |
+          az storage blob upload-batch --auth-mode login -d $Env:azureStorageBlobContainerName --account-name $Env:azureStorageAccountName --destination-path "dsve/v/$Env:newVersionNumber/" --source "./actions-tmp/"
+
+      - name: Purge CDN cache
+        shell: pwsh
+        env:
+          azureCDNProfileName: ${{secrets.AZURE_CDN_PROFILE_NAME}}
+          azureCDNEndpointName: ${{secrets.AZURE_CDN_ENDPOINT_NAME}}
+          azureCDNResourceGroup: ${{secrets.AZURE_CDN_PROFILE_RESOURCE_GROUP}}
+        run: |
+          az cdn endpoint purge --content-paths "/dsve/*" --profile-name $Env:azureCDNProfileName --name $Env:azureCDNEndpointName --resource-group $Env:azureCDNResourceGroup

--- a/.github/workflows/sanitize-commit.yaml
+++ b/.github/workflows/sanitize-commit.yaml
@@ -1,0 +1,37 @@
+name: sanatize-commnit
+on:
+  pull_request:
+    types: [opened, reopened, edited, synchronize]
+jobs:
+  check-commit:
+    name: Check commit message
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Checks what kind of release this is based on the commit message, doc changes does not trigger a new release
+        # Uses the same script as the same step in the release-and-publish workflow. This script errors out if the naming convention is not followed.
+      - name: Check release type
+        id: releaseType
+        run: .github/workflows/scripts/shared/determineReleaseType.ps1
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          repoPath: ${{ github.repository }}
+          gitHubHost: ${{ github.server_url }}
+          prPath: ${{ github.ref }}
+
+
+      - name: Approve the Pull Request
+        id: approvePullRequest
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          repoPath: ${{ github.repository }}
+          gitHubHost: ${{ github.server_url }}
+          prPath: ${{ github.ref }}
+          releaseType: ${{ steps.releaseType.outputs.releaseType }}
+          commitMessage: ${{ steps.releaseType.outputs.commitMessage }}
+
+        run: .github/workflows/scripts/sanitize-commit/approve-pull-request.ps1

--- a/.github/workflows/scripts/release-and-publish/findNewVersion.ps1
+++ b/.github/workflows/scripts/release-and-publish/findNewVersion.ps1
@@ -1,0 +1,40 @@
+$RepositoryHost = $Env:RepositoryHost.Substring($Env:RepositoryHost.indexOf("/") + 1)
+$RepositoryURI = "$Env:RepositoryHost/$Env:RepositoryURI"
+$CurrentRelease = gh release view --repo $RepositoryURI --json name,tagName,createdAt,body | ConvertFrom-Json
+
+Write-Output "::notice::Latest release in this repository was a release with name: $($CurrentRelease.name), tag version: $($CurrentRelease.tagName)"
+
+$MajorVersionNumber = [int]$CurrentRelease.tagName.split(".")[0]
+$NormalVersionNumber = [int]$CurrentRelease.tagName.split(".")[1]
+$MinorVersionNumber = [int]$CurrentRelease.tagName.split(".")[2]
+
+$NewMinorVersionNumber = $MinorVersionNumber
+$NewNormalVersionNumber = $NormalVersionNumber
+$NewMajorVersionNumber = $MajorVersionNumber
+
+switch ($Env:ReleaseType) {
+  fix {
+    $NewMinorVersionNumber = $MinorVersionNumber + 1
+    Write-Output "::notice::Increasing minor version number from: $MinorVersionNumber to $NewMinorVersionNumber"
+  }
+  feat {
+    $NewNormalVersionNumber = $NormalVersionNumber + 1
+    $NewMinorVersionNumber = 0
+    Write-Output "::notice::Increasing middle version number from: $NormalVersionNumber to $NewNormalVersionNumber"
+    Write-Output "::notice::Resetting minor version number from: $MinorVersionNumber to $NewMinorVersionNumber"
+  }
+  breaking {
+    $NewMajorVersionNumber = $MajorVersionNumber + 1
+    $NewNormalVersionNumber = 0
+    $NewMinorVersionNumber = 0
+    Write-Output "::notice::Increasing major version number from: $MajorVersionNumber to $NewMajorVersionNumber"
+    Write-Output "::notice::Resetting middle version number from: $NormalVersionNumber to $NewNormalVersionNumber"
+    Write-Output "::notice::Resetting minor version number from: $MinorVersionNumber to $NewMinorVersionNumber"
+  }
+}
+
+$NewTagVersion = "$NewMajorVersionNumber.$NewNormalVersionNumber.$NewMinorVersionNumber"
+
+Write-Output "::notice::New version is: $NewTagVersion"
+
+Add-Content -Value "newVersionNumber=$NewTagVersion" -Path $Env:GITHUB_OUTPUT -Encoding utf8

--- a/.github/workflows/scripts/release-and-publish/uploadAfpantFilesToAzure.ps1
+++ b/.github/workflows/scripts/release-and-publish/uploadAfpantFilesToAzure.ps1
@@ -1,0 +1,8 @@
+New-Item -Path "./" -Name "actions-tmp" -ItemType "Directory" | Out-Null
+New-Item -Path "./actions-tmp" -Name "xslt" -ItemType "Directory" | Out-Null
+New-Item -Path "./actions-tmp" -Name "xsd" -ItemType "Directory" | Out-Null
+New-Item -Path "./actions-tmp" -Name "xml" -ItemType "Directory" | Out-Null
+Get-ChildItem -Path 'spesifikasjoner/afpant/' -Recurse -Include *.xslt | ForEach-Object -Process { Copy-Item $_.VersionInfo.FileName ./actions-tmp/xslt/ }
+Get-ChildItem -Path 'spesifikasjoner/afpant/' -Recurse -Include *.xsd | ForEach-Object -Process { Copy-Item $_.VersionInfo.FileName ./actions-tmp/xsd }
+Get-ChildItem -Path 'spesifikasjoner/afpant/' -Recurse -Include *.xml | ForEach-Object -Process { Copy-Item $_.VersionInfo.FileName ./actions-tmp/xml }
+Get-ChildItem -Path 'actions-tmp' -Recurse -Include "*.*" | ForEach-Object -Process { Write-Output "::notice::Uploading file: $($_.Name.Substring($_.Name.lastIndexOf('/') + 1))" }

--- a/.github/workflows/scripts/sanitize-commit/approve-pull-request.ps1
+++ b/.github/workflows/scripts/sanitize-commit/approve-pull-request.ps1
@@ -1,0 +1,23 @@
+#Find PR URL
+$mergeLessPRPath = $Env:prPath.Substring(0, $Env:prPath.indexOf("/merge")) #Trim off "/merge"
+$PullRequestUrl = "$Env:gitHubHost/$Env:repoPath/$($mergeLessPRPath.Substring($mergeLessPRPath.indexOf("pull/")))" #Combine to URL, remove "/refs" i.e only include "pull/<nr>"
+
+switch ($Env:releaseType) {
+  doc {
+    Write-Output "::notice::The latest commit indicates a documentation change. Merging this pull-request will not alter the version number."
+    gh pr comment $PullRequestUrl --body "The naming is confirmed. The latest commit indicates a documentation change. Merging this pull-request will not alter the version number."
+    exit 0
+  } fix {
+    Write-Output "::notice::The latest commit: $Env:commitMessage indicates a fix change. Merging this pull-request will increase the minor (0.0.x) version number."
+    gh pr comment $PullRequestUrl --body "The naming is confirmed. The latest commit: '$Env:commitMessage' indicates a fix change. Merging this pull-request will increase the minor (0.0.x) version number."
+    exit 0
+  } feat {
+    Write-Output "::notice::The latest commit: $Env:commitMessage indicates a non-breaking feature change. Merging this pull-request will increase the middle (0.x.0) version number."
+    gh pr comment $PullRequestUrl --body "The naming is confirmed. The latest commit: '$Env:commitMessage' indicates a non-breaking feature change. Merging this pull-request will increase the middle (0.x.0) version number."
+    exit 0
+  } breaking {
+    Write-Output "::notice::The latest commit: $Env:commitMessage indicates a breaking feature change. Merging this pull-request will increase the major (x.0.0) version number."
+    gh pr comment $PullRequestUrl --body "The naming is confirmed. The latest commit: '$Env:commitMessage' indicates a breaking feature change. Merging this pull-request will increase the major (x.0.0) version number."
+    exit 0
+  }
+}

--- a/.github/workflows/scripts/shared/determineReleaseType.ps1
+++ b/.github/workflows/scripts/shared/determineReleaseType.ps1
@@ -1,0 +1,53 @@
+$CommitMessage = ""
+# /////////// Determine commit message \\\\\\\\\\\\\\\\\\\\\\\
+if ( ($null -ne $Env:prPath) -and ($null -ne $Env:mergeCommitMessage) ) { #If booth methoods are present somthing is wrong
+  Write-Output "::error title=Script-Error::Both the 'prPath' and 'mergeCommitMessage' environment variables are used, this is wrong, check the pipeline workflow"
+} elseif ($null -ne $Env:prPath) { #If we have a Pull-Request Path that means that this was triggered by a pull-request, we need to find the last commit in the Pull-Request
+  #Find pull-request URL:
+  $mergeLessPRPath = $Env:prPath.Substring(0, $Env:prPath.indexOf("/merge")) #Trim off "/merge"
+  $PullRequestUrl = "$Env:gitHubHost/$Env:repoPath/$($mergeLessPRPath.Substring($mergeLessPRPath.indexOf("pull/")))" #Combine to URL, remove "/refs" i.e only include "pull/<nr>"
+
+  $CommitMessage = gh pr view $PullRequestUrl --json commits | ConvertFrom-Json | Select-Object -Expand commits | ForEach-Object { $_.messageHeadline } | Select-Object -Last 1
+
+  if ($CommitMessage -match '^Merge.*') { #If a merge conflict was solved the commit message might not follow the standard, jumping one up
+    Write-Output "::notify::The last commit on the pull request: $PullRequestUrl contained 'Merge' on the last commit message, this might be due to a merge-conflict resolution, checking previous to last commit message"
+    $CommitMessage = gh pr view $PullRequestUrl --json commits | ConvertFrom-Json | Select-Object -Expand commits | ForEach-Object { $_.messageHeadline } | Select-Object -Last 2 | Select-Object -First 1
+  }
+} elseif ($null -ne $Env:mergeCommitMessage) { #If this is not null, then the commit message was a merge commit message, we need to find the final commit message of the merge branch
+  if ( $Env:mergeCommitMessage -notmatch '^(Merge pull request #)[0-9]( from ).*') {
+    Write-Output "::error title=Script-Error::The script has encountered an error while attempting to find the release type. The script got the commit message as input, which means that this was called as part of a push to the master branch, but the commit message did not follow the regex pattern for a merge commit, this means that somone pushed straight to master. Naughty Naughty! The commit message was: $Env:mergeCommitMessage"
+    exit 1
+  } else { #Find the last Pull-Request commit message using the PR number from the commit message of the merge commit message
+    $NoAfterNumber = $Env:mergeCommitMessage.Substring(0, $Env:mergeCommitMessage.indexOf("from"))
+    [Int]$PullRequestNumber = $NoAfterNumber.Substring($NoAfterNumber.indexOf("#") + 1)
+    $PullRequestUrl = "$Env:gitHubHost/$Env:repoPath/pull/$PullRequestNumber"
+
+    $CommitMessage = gh pr view $PullRequestUrl --json commits | ConvertFrom-Json | Select-Object -Expand commits | ForEach-Object { $_.messageHeadline } | Select-Object -Last 1
+
+    if ($CommitMessage -match '^Merge.*') { #If a merge conflict was solved the commit message might not follow the standard, jumping one up
+      Write-Output "::notify::The last commit on the pull request: $PullRequestUrl contained 'Merge' on the last commit message, this might be due to a merge-conflict resolution, checking previous to last commit message"
+      $CommitMessage = gh pr view $PullRequestUrl --json commits | ConvertFrom-Json | Select-Object -Expand commits | ForEach-Object { $_.messageHeadline } | Select-Object -Last 2 | Select-Object -First 1
+    }
+  }
+} else {
+  Write-Output "::error title=Script-Error::Either the 'prPath' and 'mergeCommitMessage' environment variables must be included, found none."
+}
+
+#///////////////// Determine release type based on commit message. \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+if ( $CommitMessage -match '^doc:(\s|\S)*$') {
+  $releaseType = 'doc'
+} elseif ( $CommitMessage -match '^fix:(\s|\S)*$' ) {
+  $releaseType = 'fix'
+} elseif ( $CommitMessage -match '^feat:(\s|\S)*$' ) {
+  $releaseType = 'feat'
+} elseif ( $CommitMessage -match '^feat!:(\s|\S)*$' ) {
+  $releaseType = 'breaking'
+} else {
+  Write-Output "::error title=Naming-Convention-Error::The commit message did not follow the agreed upon naming convention, the name of the lates commit was: $CommitMessage"
+  exit 1
+}
+
+Write-Output "::notice::The merge was determined to be a $releaseType change"
+
+Add-Content -Value "releaseType=$releaseType" -Path $Env:GITHUB_OUTPUT -Encoding utf8
+Add-Content -Value "commitMessage=$CommitMessage" -Path $Env:GITHUB_OUTPUT -Encoding utf8

--- a/spesifikasjoner/afpant/afpant-gjennomfoertetinglysing/gjennommfoertetinglysing.md
+++ b/spesifikasjoner/afpant/afpant-gjennomfoertetinglysing/gjennommfoertetinglysing.md
@@ -9,15 +9,15 @@ Når bank sender kjøpers pantedokument elektronisk til megler i form av en Sign
 ## Validering og ruting
 
 ### Krav til filnavn i ZIP-arkiv
-- Payload filen med GjennomfoertEtinglysing melding må følge konvensjonen "gjennomfoertetinglysing_*.zip".
-- Vedlegget med forsendelsesstatus fra Kartverket må følge konvensjonen "forsendelsesstatus_*.xml".
+- Payload filen med GjennomfoertEtinglysing melding må følge konvensjonen `gjennomfoertetinglysing_*.xml`.
+- Vedlegget med forsendelsesstatus fra Kartverket må følge konvensjonen `forsendelsesstatus_*.xml`.
 
 ### Ruting (meglersystem)
 Når meglers systemleverandør mottar forsendelsesstatus fra Kartverket som tilsier at en forsendelse er vellykket e-tingyst, må systemleverandøren sjekke om forsendelsen inneholder ett eller flere kjøpers pantedokument fra bank.
 
 For hver av disse pantedokumentene må meglers systemleverandør utføre følgende:
 1. Finn organisasjonsnummer for Altinn reportee som sendte SignedMortgageDeed melding til megler med det aktuelle pantedokumentet. Dette organisasjonsnummeret regnes for å være avsender bank som skal motta GjennomfoertEtinglysing melding.
-2. Sjekk om avsender bankens organisasjonsnummer er registrert i Akeldo med støtte for meldingstypen "GjennomfoertEtinglysing". Dersom ja, send GjennomfoertEtinglysing melding til dette organisasjonsnummeret.
+2. Sjekk om avsender bankens organisasjonsnummer er registrert i Akeldo med støtte i mottaksliste for meldingstypen "GjennomfoertEtinglysing". Dersom ja, send GjennomfoertEtinglysing melding til dette organisasjonsnummeret.
 
 Merknad: flere pantedokumenter i samme e-tinglysing forsendelse fra samme bank, gitt at banken støtter meldingstypen i Akeldo, medfører GjennomfoertEtinglysing meldinger til banken for hvert enkelt av disse pantedokumentene.
 
@@ -38,7 +38,7 @@ Meldingstypen GjennomfoertEtinglysing sendes fra megler til bank for å informer
 
 ### Payload
 Et ZIP-arkiv med 2 filer:
-- En GjennomfoertEtinglysing XML med data ihht. [definert skjema.](../afpant-model/xsd/dsve.xsd)
+- En GjennomfoertEtinglysing XML med data ihht. [definert skjema](../afpant-model/xsd/dsve.xsd).
 - Et vedlegg med forsendelsesstatus xml data fra Kartverket til megler for forsendelsen 
 som inkluderte det aktuelle kjøpers pantedokumentet.
 

--- a/spesifikasjoner/afpant/afpant-model/afpant-model.md
+++ b/spesifikasjoner/afpant/afpant-model/afpant-model.md
@@ -1,0 +1,3 @@
+## Testing
+
+For å teste xml-eksemplene, naviger til `spesifikasjoner/afpant/afpant-model` og kjør `npx http-server`. Deretter kan du åpne xml-eksemplene i nettleseren din, feks http://127.0.0.1:8080/examples/innfrielsessaldoforespoersel_1.0.xml eller http://127.0.0.1:8080/examples/innfrielsessaldosvar_1.0.xml.

--- a/spesifikasjoner/afpant/afpant-model/examples/innfrielsessaldoforespoersel_1.0.xml
+++ b/spesifikasjoner/afpant/afpant-model/examples/innfrielsessaldoforespoersel_1.0.xml
@@ -63,6 +63,8 @@
               <poststed>Oslo</poststed>
             </adresse>
           </organisasjon>
+        </hjemmelshaver>
+        <hjemmelshaver>
           <person id="01017613245">
             <fornavn>Kari</fornavn>
             <etternavn>Nordmann</etternavn>
@@ -86,10 +88,6 @@
               <poststed>Oslo</poststed>
             </adresse>
           </organisasjon>
-          <person id="01017613246">
-            <fornavn>Jan</fornavn>
-            <etternavn>Nordmann</etternavn>
-          </person>
         </hjemmelshaver>
       </hjemmelshavere>
     </registerenhetMedHjemmelshavere>
@@ -98,17 +96,6 @@
       <hjemmelshavere>
         <!--1 or more repetitions:-->
         <hjemmelshaver>
-          <!--You have a CHOICE of the next 2 items at this level-->
-          <organisasjon id="928000004">
-            <foretaksnavn>HJEMMELSHAVER 2 AS</foretaksnavn>
-            <!--Optional:-->
-            <adresse>
-              <!--Optional:-->
-              <gatenavn>Gatenavn 5</gatenavn>
-              <postnummer>1234</postnummer>
-              <poststed>Oslo</poststed>
-            </adresse>
-          </organisasjon>
           <person id="01017613246">
             <fornavn>Jan</fornavn>
             <etternavn>Nordmann</etternavn>
@@ -120,6 +107,7 @@
   <innfrielsesdatoer>
     <!--1 or more repetitions:-->
     <innfrielsesdato>2005-03-13</innfrielsesdato>
+    <innfrielsesdato>2005-03-14</innfrielsesdato>
   </innfrielsesdatoer>
   <metadata>
     <!--Optional:-->

--- a/spesifikasjoner/afpant/afpant-model/examples/innfrielsessaldoforespoersel_1.0.xml
+++ b/spesifikasjoner/afpant/afpant-model/examples/innfrielsessaldoforespoersel_1.0.xml
@@ -1,72 +1,72 @@
 <innfrielsessaldoforespoersel>
-  <avsender id="string">
-    <foretaksnavn>string</foretaksnavn>
+  <avsender id="928000000">
+    <foretaksnavn>AVSENDER AS</foretaksnavn>
     <!--Optional:-->
     <adresse>
       <!--Optional:-->
-      <gatenavn>string</gatenavn>
-      <postnummer>string</postnummer>
-      <poststed>string</poststed>
+      <gatenavn>Gatenavn 1</gatenavn>
+      <postnummer>1234</postnummer>
+      <poststed>Oslo</poststed>
     </adresse>
     <!--Optional:-->
     <kontaktperson>
-      <navn>string</navn>
+      <navn>Ola Nordmann</navn>
       <!--Optional:-->
-      <epost>string</epost>
+      <epost>ola.nordmann@foretaksnavn.no</epost>
       <!--Optional:-->
-      <telefondirekte>string</telefondirekte>
+      <telefondirekte>12345678</telefondirekte>
       <!--Optional:-->
-      <telefon>string</telefon>
+      <telefon>12345678</telefon>
     </kontaktperson>
-    <referanse>string</referanse>
+    <referanse>REF-123</referanse>
     <!--Optional:-->
-    <returnertil id="string">
-      <foretaksnavn>string</foretaksnavn>
+    <returnertil id="928000001">
+      <foretaksnavn>RETURNERTIL AS</foretaksnavn>
       <!--Optional:-->
       <adresse>
         <!--Optional:-->
-        <gatenavn>string</gatenavn>
-        <postnummer>string</postnummer>
-        <poststed>string</poststed>
+        <gatenavn>Gatenavn 2</gatenavn>
+        <postnummer>1234</postnummer>
+        <poststed>Oslo</poststed>
       </adresse>
     </returnertil>
   </avsender>
-  <mottaker id="string">
-    <foretaksnavn>string</foretaksnavn>
+  <mottaker id="928000002">
+    <foretaksnavn>MOTTAKER AS</foretaksnavn>
     <!--Optional:-->
     <adresse>
       <!--Optional:-->
-      <gatenavn>string</gatenavn>
-      <postnummer>string</postnummer>
-      <poststed>string</poststed>
+      <gatenavn>Gatenavn 3</gatenavn>
+      <postnummer>1234</postnummer>
+      <poststed>Oslo</poststed>
     </adresse>
     <!--Optional:-->
-    <referanse>string</referanse>
+    <referanse>REF-456</referanse>
   </mottaker>
   <registerenheterMedHjemmelshavere>
     <!--1 or more repetitions:-->
     <registerenhetMedHjemmelshavere>
       <!--You have a CHOICE of the next 3 items at this level-->
-      <matrikkel kommunenavn="string" kommunenummer="string" gaardsnummer="string" bruksnummer="string" festenummer="string" seksjonsnummer="string" eiendomsnivaa="F"/>
-      <borettsandel organisasjonsnummer="string" borettslagnavn="string" andelsnummer="string"/>
-      <aksjeleilighet organisasjonsnummer="string" organisasjonsnavn="string" leilighetsnummer="string"/>
+      <matrikkel kommunenavn="Oslo" kommunenummer="0301" gaardsnummer="1" bruksnummer="2" festenummer="3" seksjonsnummer="4" eiendomsnivaa="F"/>
+      <borettsandel organisasjonsnummer="123456789" borettslagnavn="Borettslaget" andelsnummer="1"/>
+      <aksjeleilighet organisasjonsnummer="123456789" organisasjonsnavn="Aksjeselskapet" leilighetsnummer="1"/>
       <hjemmelshavere>
         <!--1 or more repetitions:-->
         <hjemmelshaver>
           <!--You have a CHOICE of the next 2 items at this level-->
-          <organisasjon id="string">
-            <foretaksnavn>string</foretaksnavn>
+          <organisasjon id="928000003">
+            <foretaksnavn>HJEMMELSHAVER 1 AS</foretaksnavn>
             <!--Optional:-->
             <adresse>
               <!--Optional:-->
-              <gatenavn>string</gatenavn>
-              <postnummer>string</postnummer>
-              <poststed>string</poststed>
+              <gatenavn>Gatenavn 4</gatenavn>
+              <postnummer>1234</postnummer>
+              <poststed>Oslo</poststed>
             </adresse>
           </organisasjon>
-          <person id="string">
-            <fornavn>string</fornavn>
-            <etternavn>string</etternavn>
+          <person id="01017613245">
+            <fornavn>Kari</fornavn>
+            <etternavn>Nordmann</etternavn>
           </person>
         </hjemmelshaver>
       </hjemmelshavere>
@@ -81,10 +81,10 @@
     <ressurser>
       <!--Zero or more repetitions:-->
       <vedlegg>
-        <navn>string</navn>
-        <mimetype>string</mimetype>
+        <navn>Vedlegg 1</navn>
+        <mimetype>application/pdf</mimetype>
         <!--Optional:-->
-        <beskrivelse>string</beskrivelse>
+        <beskrivelse>Beskrivelse av vedlegg 1</beskrivelse>
       </vedlegg>
     </ressurser>
     <opprettet>2004-01-17T04:42:06</opprettet>

--- a/spesifikasjoner/afpant/afpant-model/examples/innfrielsessaldoforespoersel_1.0.xml
+++ b/spesifikasjoner/afpant/afpant-model/examples/innfrielsessaldoforespoersel_1.0.xml
@@ -1,3 +1,4 @@
+<?xml-stylesheet type="text/xsl" href="../xslt/restgjeld.xslt"?>
 <innfrielsessaldoforespoersel>
   <avsender id="928000000">
     <foretaksnavn>AVSENDER AS</foretaksnavn>

--- a/spesifikasjoner/afpant/afpant-model/examples/innfrielsessaldoforespoersel_1.0.xml
+++ b/spesifikasjoner/afpant/afpant-model/examples/innfrielsessaldoforespoersel_1.0.xml
@@ -1,104 +1,119 @@
 <?xml-stylesheet type="text/xsl" href="../xslt/restgjeld.xslt"?>
 <innfrielsessaldoforespoersel>
-  <avsender id="928000000">
-    <foretaksnavn>AVSENDER AS</foretaksnavn>
+  <avsender id="910968955">
+    <foretaksnavn>DNB EIENDOM AS</foretaksnavn>
     <!--Optional:-->
     <adresse>
       <!--Optional:-->
-      <gatenavn>Gatenavn 1</gatenavn>
-      <postnummer>1234</postnummer>
+      <gatenavn>Dronning Eufemias gate 30</gatenavn>
+      <postnummer>0191</postnummer>
       <poststed>Oslo</poststed>
     </adresse>
     <!--Optional:-->
     <kontaktperson>
-      <navn>Ola Nordmann</navn>
+      <navn>Ole Meglersen</navn>
       <!--Optional:-->
-      <epost>ola.nordmann@foretaksnavn.no</epost>
+      <epost>ole.meglersen@dnbeiendom.no</epost>
       <!--Optional:-->
-      <telefondirekte>12345678</telefondirekte>
+      <telefondirekte>98765432</telefondirekte>
       <!--Optional:-->
-      <telefon>12345678</telefon>
+      <telefon>22223344</telefon>
     </kontaktperson>
-    <referanse>REF-123</referanse>
+    <referanse>OPGNR-123</referanse>
     <!--Optional:-->
-    <returnertil id="928000001">
-      <foretaksnavn>RETURNERTIL AS</foretaksnavn>
+    <returnertil id="910968955">
+      <foretaksnavn>DNB EIENDOM (retur) AS</foretaksnavn>
       <!--Optional:-->
       <adresse>
         <!--Optional:-->
-        <gatenavn>Gatenavn 2</gatenavn>
-        <postnummer>1234</postnummer>
+        <gatenavn>Dronning Eufemias gate 32</gatenavn>
+        <postnummer>0191</postnummer>
         <poststed>Oslo</poststed>
       </adresse>
     </returnertil>
   </avsender>
-  <mottaker id="928000002">
-    <foretaksnavn>MOTTAKER AS</foretaksnavn>
-    <!--Optional:-->
-    <adresse>
-      <!--Optional:-->
-      <gatenavn>Gatenavn 3</gatenavn>
-      <postnummer>1234</postnummer>
-      <poststed>Oslo</poststed>
-    </adresse>
-    <!--Optional:-->
-    <referanse>REF-456</referanse>
+  <mottaker id="984851006">
+    <foretaksnavn>DNB BANK ASA</foretaksnavn>
   </mottaker>
   <registerenheterMedHjemmelshavere>
     <!--1 or more repetitions:-->
     <registerenhetMedHjemmelshavere>
       <!--You have a CHOICE of the next 3 items at this level-->
-      <matrikkel kommunenavn="Oslo" kommunenummer="0301" gaardsnummer="1" bruksnummer="2" festenummer="3" seksjonsnummer="4" eiendomsnivaa="F"/>
+      <matrikkel kommunenavn="Lillestrøm" kommunenummer="3205" gaardsnummer="273" bruksnummer="220" festenummer="0" seksjonsnummer="12" eiendomsnivaa="E"/>
       <hjemmelshavere>
         <!--1 or more repetitions:-->
         <hjemmelshaver>
           <!--You have a CHOICE of the next 2 items at this level-->
-          <organisasjon id="928000003">
-            <foretaksnavn>HJEMMELSHAVER 1 AS</foretaksnavn>
-            <!--Optional:-->
-            <adresse>
-              <!--Optional:-->
-              <gatenavn>Gatenavn 4</gatenavn>
-              <postnummer>1234</postnummer>
-              <poststed>Oslo</poststed>
-            </adresse>
+          <person id="17050033455">
+            <fornavn>Ola</fornavn>
+            <etternavn>Normann</etternavn>
+          </person>
+        </hjemmelshaver>
+        <hjemmelshaver>
+          <!--You have a CHOICE of the next 2 items at this level-->
+          <organisasjon id="889693622">
+            <foretaksnavn>SANDSLI EIENDOMSUTVIKLING AS</foretaksnavn>
           </organisasjon>
         </hjemmelshaver>
         <hjemmelshaver>
-          <person id="01017613245">
+          <!--You have a CHOICE of the next 2 items at this level-->
+          <person id="02027812345">
             <fornavn>Kari</fornavn>
-            <etternavn>Nordmann</etternavn>
+            <etternavn>Normann</etternavn>
           </person>
         </hjemmelshaver>
       </hjemmelshavere>
     </registerenhetMedHjemmelshavere>
     <registerenhetMedHjemmelshavere>
-      <borettsandel organisasjonsnummer="123456789" borettslagnavn="Borettslaget" andelsnummer="1"/>
+      <!--You have a CHOICE of the next 3 items at this level-->
+      <borettsandel organisasjonsnummer="954442403" borettslagnavn="Feråsen borettslag" andelsnummer="71"/>
       <hjemmelshavere>
         <!--1 or more repetitions:-->
         <hjemmelshaver>
           <!--You have a CHOICE of the next 2 items at this level-->
-          <organisasjon id="928000004">
-            <foretaksnavn>HJEMMELSHAVER 2 AS</foretaksnavn>
-            <!--Optional:-->
-            <adresse>
-              <!--Optional:-->
-              <gatenavn>Gatenavn 5</gatenavn>
-              <postnummer>1234</postnummer>
-              <poststed>Oslo</poststed>
-            </adresse>
+          <person id="17050033455">
+            <fornavn>Ola</fornavn>
+            <etternavn>Normann</etternavn>
+          </person>
+        </hjemmelshaver>
+        <hjemmelshaver>
+          <!--You have a CHOICE of the next 2 items at this level-->
+          <organisasjon id="889693622">
+            <foretaksnavn>SANDSLI EIENDOMSUTVIKLING AS</foretaksnavn>
           </organisasjon>
+        </hjemmelshaver>
+        <hjemmelshaver>
+          <!--You have a CHOICE of the next 2 items at this level-->
+          <person id="02027812345">
+            <fornavn>Kari</fornavn>
+            <etternavn>Normann</etternavn>
+          </person>
         </hjemmelshaver>
       </hjemmelshavere>
     </registerenhetMedHjemmelshavere>
     <registerenhetMedHjemmelshavere>
-      <aksjeleilighet organisasjonsnummer="123456789" organisasjonsnavn="Aksjeselskapet" leilighetsnummer="1"/>
+      <!--You have a CHOICE of the next 3 items at this level-->
+      <aksjeleilighet organisasjonsnummer="954442403" organisasjonsnavn="Feråsen Akjselag" leilighetsnummer="71"/>
       <hjemmelshavere>
         <!--1 or more repetitions:-->
         <hjemmelshaver>
-          <person id="01017613246">
-            <fornavn>Jan</fornavn>
-            <etternavn>Nordmann</etternavn>
+          <!--You have a CHOICE of the next 2 items at this level-->
+          <person id="17050033455">
+            <fornavn>Ola</fornavn>
+            <etternavn>Normann</etternavn>
+          </person>
+        </hjemmelshaver>
+        <hjemmelshaver>
+          <!--You have a CHOICE of the next 2 items at this level-->
+          <organisasjon id="889693622">
+            <foretaksnavn>SANDSLI EIENDOMSUTVIKLING AS</foretaksnavn>
+          </organisasjon>
+        </hjemmelshaver>
+        <hjemmelshaver>
+          <!--You have a CHOICE of the next 2 items at this level-->
+          <person id="02027812345">
+            <fornavn>Kari</fornavn>
+            <etternavn>Normann</etternavn>
           </person>
         </hjemmelshaver>
       </hjemmelshavere>
@@ -106,8 +121,8 @@
   </registerenheterMedHjemmelshavere>
   <innfrielsesdatoer>
     <!--1 or more repetitions:-->
-    <innfrielsesdato>2005-03-13</innfrielsesdato>
-    <innfrielsesdato>2005-03-14</innfrielsesdato>
+    <innfrielsesdato>2025-05-13</innfrielsesdato>
+    <innfrielsesdato>2025-05-14</innfrielsesdato>
   </innfrielsesdatoer>
   <metadata>
     <!--Optional:-->

--- a/spesifikasjoner/afpant/afpant-model/examples/innfrielsessaldoforespoersel_1.0.xml
+++ b/spesifikasjoner/afpant/afpant-model/examples/innfrielsessaldoforespoersel_1.0.xml
@@ -49,8 +49,6 @@
     <registerenhetMedHjemmelshavere>
       <!--You have a CHOICE of the next 3 items at this level-->
       <matrikkel kommunenavn="Oslo" kommunenummer="0301" gaardsnummer="1" bruksnummer="2" festenummer="3" seksjonsnummer="4" eiendomsnivaa="F"/>
-      <borettsandel organisasjonsnummer="123456789" borettslagnavn="Borettslaget" andelsnummer="1"/>
-      <aksjeleilighet organisasjonsnummer="123456789" organisasjonsnavn="Aksjeselskapet" leilighetsnummer="1"/>
       <hjemmelshavere>
         <!--1 or more repetitions:-->
         <hjemmelshaver>
@@ -67,6 +65,52 @@
           </organisasjon>
           <person id="01017613245">
             <fornavn>Kari</fornavn>
+            <etternavn>Nordmann</etternavn>
+          </person>
+        </hjemmelshaver>
+      </hjemmelshavere>
+    </registerenhetMedHjemmelshavere>
+    <registerenhetMedHjemmelshavere>
+      <borettsandel organisasjonsnummer="123456789" borettslagnavn="Borettslaget" andelsnummer="1"/>
+      <hjemmelshavere>
+        <!--1 or more repetitions:-->
+        <hjemmelshaver>
+          <!--You have a CHOICE of the next 2 items at this level-->
+          <organisasjon id="928000004">
+            <foretaksnavn>HJEMMELSHAVER 2 AS</foretaksnavn>
+            <!--Optional:-->
+            <adresse>
+              <!--Optional:-->
+              <gatenavn>Gatenavn 5</gatenavn>
+              <postnummer>1234</postnummer>
+              <poststed>Oslo</poststed>
+            </adresse>
+          </organisasjon>
+          <person id="01017613246">
+            <fornavn>Jan</fornavn>
+            <etternavn>Nordmann</etternavn>
+          </person>
+        </hjemmelshaver>
+      </hjemmelshavere>
+    </registerenhetMedHjemmelshavere>
+    <registerenhetMedHjemmelshavere>
+      <aksjeleilighet organisasjonsnummer="123456789" organisasjonsnavn="Aksjeselskapet" leilighetsnummer="1"/>
+      <hjemmelshavere>
+        <!--1 or more repetitions:-->
+        <hjemmelshaver>
+          <!--You have a CHOICE of the next 2 items at this level-->
+          <organisasjon id="928000004">
+            <foretaksnavn>HJEMMELSHAVER 2 AS</foretaksnavn>
+            <!--Optional:-->
+            <adresse>
+              <!--Optional:-->
+              <gatenavn>Gatenavn 5</gatenavn>
+              <postnummer>1234</postnummer>
+              <poststed>Oslo</poststed>
+            </adresse>
+          </organisasjon>
+          <person id="01017613246">
+            <fornavn>Jan</fornavn>
             <etternavn>Nordmann</etternavn>
           </person>
         </hjemmelshaver>

--- a/spesifikasjoner/afpant/afpant-model/examples/innfrielsessaldosvar_1.0.xml
+++ b/spesifikasjoner/afpant/afpant-model/examples/innfrielsessaldosvar_1.0.xml
@@ -77,11 +77,25 @@
     <registerenhetMedDokumentreferanse>
       <!--You have a CHOICE of the next 3 items at this level-->
       <matrikkel kommunenavn="Oslo" kommunenummer="0301" gaardsnummer="1" bruksnummer="2" festenummer="3" seksjonsnummer="4" eiendomsnivaa="F"/>
+      <pantedokumentreferanser>
+        <!--Zero or more repetitions:-->
+        <pantedokumentreferanse dokumentnummer="3" dokumentaar="1" embetenummer="201" rettsstiftelsesnummer="201" registreringstidspunkt="2017-11-03T04:12:42" beloep="101010"/>
+      </pantedokumentreferanser>
+    </registerenhetMedDokumentreferanse>
+    <registerenhetMedDokumentreferanse>
+      <!--You have a CHOICE of the next 3 items at this level-->
       <borettsandel organisasjonsnummer="123456789" borettslagnavn="Borettslaget" andelsnummer="1"/>
+      <pantedokumentreferanser>
+        <!--Zero or more repetitions:-->
+        <pantedokumentreferanse dokumentnummer="3" dokumentaar="1" embetenummer="201" rettsstiftelsesnummer="201" registreringstidspunkt="2017-11-03T04:12:42" beloep="2010111"/>
+      </pantedokumentreferanser>
+    </registerenhetMedDokumentreferanse>
+    <registerenhetMedDokumentreferanse>
+      <!--You have a CHOICE of the next 3 items at this level-->
       <aksjeleilighet organisasjonsnummer="123456789" organisasjonsnavn="Aksjeselskapet" leilighetsnummer="1"/>
       <pantedokumentreferanser>
         <!--Zero or more repetitions:-->
-        <pantedokumentreferanse dokumentnummer="3" dokumentaar="1" embetenummer="201" rettsstiftelsesnummer="201" registreringstidspunkt="2017-11-03T04:12:42" beloep="201"/>
+        <pantedokumentreferanse dokumentnummer="3" dokumentaar="1" embetenummer="201" rettsstiftelsesnummer="201" registreringstidspunkt="2017-11-03T04:12:42" beloep="13"/>
       </pantedokumentreferanser>
     </registerenhetMedDokumentreferanse>
   </registerenheterMedDokumentreferanser>

--- a/spesifikasjoner/afpant/afpant-model/examples/innfrielsessaldosvar_1.0.xml
+++ b/spesifikasjoner/afpant/afpant-model/examples/innfrielsessaldosvar_1.0.xml
@@ -1,59 +1,59 @@
 <innfrielsessaldosvar>
-  <avsender id="string">
-    <foretaksnavn>string</foretaksnavn>
+  <avsender id="928000000">
+    <foretaksnavn>AVSENDER AS</foretaksnavn>
     <!--Optional:-->
     <adresse>
       <!--Optional:-->
-      <gatenavn>string</gatenavn>
-      <postnummer>string</postnummer>
-      <poststed>string</poststed>
+      <gatenavn>Gatenavn 1</gatenavn>
+      <postnummer>1234</postnummer>
+      <poststed>Oslo</poststed>
     </adresse>
     <!--Optional:-->
     <kontaktperson>
-      <navn>string</navn>
+      <navn>Ola Nordmann</navn>
       <!--Optional:-->
-      <epost>string</epost>
+      <epost>ola.nordmann@foretaksnavn.no</epost>
       <!--Optional:-->
-      <telefondirekte>string</telefondirekte>
+      <telefondirekte>12345678</telefondirekte>
       <!--Optional:-->
-      <telefon>string</telefon>
+      <telefon>12345678</telefon>
     </kontaktperson>
-    <referanse>string</referanse>
+    <referanse>REF-123</referanse>
     <!--Optional:-->
-    <returnertil id="string">
-      <foretaksnavn>string</foretaksnavn>
+    <returnertil id="928000001">
+      <foretaksnavn>RETURNERTIL AS</foretaksnavn>
       <!--Optional:-->
       <adresse>
         <!--Optional:-->
-        <gatenavn>string</gatenavn>
-        <postnummer>string</postnummer>
-        <poststed>string</poststed>
+        <gatenavn>Gatenavn 2</gatenavn>
+        <postnummer>1234</postnummer>
+        <poststed>Oslo</poststed>
       </adresse>
     </returnertil>
   </avsender>
-  <mottaker id="string">
-    <foretaksnavn>string</foretaksnavn>
+  <mottaker id="928000002">
+    <foretaksnavn>MOTTAKER AS</foretaksnavn>
     <!--Optional:-->
     <adresse>
       <!--Optional:-->
-      <gatenavn>string</gatenavn>
-      <postnummer>string</postnummer>
-      <poststed>string</poststed>
+      <gatenavn>Gatenavn 3</gatenavn>
+      <postnummer>1234</postnummer>
+      <poststed>Oslo</poststed>
     </adresse>
     <!--Optional:-->
-    <referanse>string</referanse>
+    <referanse>REF-456</referanse>
   </mottaker>
   <laanliste>
     <!--1 or more repetitions:-->
     <laan>
       <laantakerIkkeHjemmelshaver>false</laantakerIkkeHjemmelshaver>
       <transporterklaering>true</transporterklaering>
-      <laanenummer>string</laanenummer>
-      <kontonummer>string</kontonummer>
+      <laanenummer>1234567890</laanenummer>
+      <kontonummer>1234567890</kontonummer>
       <!--Optional:-->
-      <kidnummer>string</kidnummer>
+      <kidnummer>1234567890</kidnummer>
       <!--Optional:-->
-      <betalingsmelding>string</betalingsmelding>
+      <betalingsmelding>Betaling til innfrielsessaldo</betalingsmelding>
       <saldoerPerDato>
         <!--1 or more repetitions:-->
         <saldoPerDato>
@@ -63,7 +63,7 @@
       </saldoerPerDato>
       <laantakereHjemmelshaver>
         <!--Zero or more repetitions:-->
-        <navn>string</navn>
+        <navn>Kari Nordmann</navn>
       </laantakereHjemmelshaver>
     </laan>
   </laanliste>
@@ -71,9 +71,9 @@
     <!--1 or more repetitions:-->
     <registerenhetMedDokumentreferanse>
       <!--You have a CHOICE of the next 3 items at this level-->
-      <matrikkel kommunenavn="string" kommunenummer="string" gaardsnummer="string" bruksnummer="string" festenummer="string" seksjonsnummer="string" eiendomsnivaa="F"/>
-      <borettsandel organisasjonsnummer="string" borettslagnavn="string" andelsnummer="string"/>
-      <aksjeleilighet organisasjonsnummer="string" organisasjonsnavn="string" leilighetsnummer="string"/>
+      <matrikkel kommunenavn="Oslo" kommunenummer="0301" gaardsnummer="1" bruksnummer="2" festenummer="3" seksjonsnummer="4" eiendomsnivaa="F"/>
+      <borettsandel organisasjonsnummer="123456789" borettslagnavn="Borettslaget" andelsnummer="1"/>
+      <aksjeleilighet organisasjonsnummer="123456789" organisasjonsnavn="Aksjeselskapet" leilighetsnummer="1"/>
       <pantedokumentreferanser>
         <!--Zero or more repetitions:-->
         <pantedokumentreferanse dokumentnummer="3" dokumentaar="1" embetenummer="201" rettsstiftelsesnummer="201" registreringstidspunkt="2017-11-03T04:12:42" beloep="201"/>
@@ -85,10 +85,10 @@
     <ressurser>
       <!--Zero or more repetitions:-->
       <vedlegg>
-        <navn>string</navn>
-        <mimetype>string</mimetype>
+        <navn>Vedlegg 1</navn>
+        <mimetype>application/pdf</mimetype>
         <!--Optional:-->
-        <beskrivelse>string</beskrivelse>
+        <beskrivelse>Beskrivelse av vedlegg 1</beskrivelse>
       </vedlegg>
     </ressurser>
     <opprettet>2003-09-03T02:04:43</opprettet>

--- a/spesifikasjoner/afpant/afpant-model/examples/innfrielsessaldosvar_1.0.xml
+++ b/spesifikasjoner/afpant/afpant-model/examples/innfrielsessaldosvar_1.0.xml
@@ -1,56 +1,26 @@
 <?xml-stylesheet type="text/xsl" href="../xslt/restgjeld.xslt"?>
 <innfrielsessaldosvar>
-  <avsender id="928000000">
-    <foretaksnavn>AVSENDER AS</foretaksnavn>
-    <!--Optional:-->
-    <adresse>
-      <!--Optional:-->
-      <gatenavn>Gatenavn 1</gatenavn>
-      <postnummer>1234</postnummer>
-      <poststed>Oslo</poststed>
-    </adresse>
-    <!--Optional:-->
+  <avsender id="984851006">
+    <foretaksnavn>DNB BANK ASA</foretaksnavn>
     <kontaktperson>
-      <navn>Ola Nordmann</navn>
-      <!--Optional:-->
-      <epost>ola.nordmann@foretaksnavn.no</epost>
-      <!--Optional:-->
-      <telefondirekte>12345678</telefondirekte>
-      <!--Optional:-->
-      <telefon>12345678</telefon>
+      <navn>Ole Bankesen</navn>
+      <epost>ole@dnb.no</epost>
+      <telefondirekte>41414141</telefondirekte>
+      <telefon>22224455</telefon>
     </kontaktperson>
-    <referanse>REF-123</referanse>
-    <!--Optional:-->
-    <returnertil id="928000001">
-      <foretaksnavn>RETURNERTIL AS</foretaksnavn>
-      <!--Optional:-->
-      <adresse>
-        <!--Optional:-->
-        <gatenavn>Gatenavn 2</gatenavn>
-        <postnummer>1234</postnummer>
-        <poststed>Oslo</poststed>
-      </adresse>
-    </returnertil>
+    <referanse>FX12398731273123</referanse>
   </avsender>
-  <mottaker id="928000002">
-    <foretaksnavn>MOTTAKER AS</foretaksnavn>
-    <!--Optional:-->
-    <adresse>
-      <!--Optional:-->
-      <gatenavn>Gatenavn 3</gatenavn>
-      <postnummer>1234</postnummer>
-      <poststed>Oslo</poststed>
-    </adresse>
-    <!--Optional:-->
-    <referanse>REF-456</referanse>
+  <mottaker id="910968955">
+    <foretaksnavn>DNB EIENDOM AS</foretaksnavn>
+    <referanse>OPGNR-123</referanse>
   </mottaker>
   <laanliste>
     <!--1 or more repetitions:-->
     <laan>
       <laantakerIkkeHjemmelshaver>false</laantakerIkkeHjemmelshaver>
       <transporterklaering>true</transporterklaering>
-      <laanenummer>1234567890</laanenummer>
-      <kontonummer>1234567890</kontonummer>
+      <laanenummer>12345678902</laanenummer>
+      <kontonummer>12345678902</kontonummer>
       <!--Optional:-->
       <kidnummer>1234567890</kidnummer>
       <!--Optional:-->
@@ -58,12 +28,37 @@
       <saldoerPerDato>
         <!--1 or more repetitions:-->
         <saldoPerDato>
-          <beloep>1.051732E7</beloep>
-          <dato>2007-08-16+02:00</dato>
+          <beloep>12345000</beloep>
+          <dato>2025-05-17</dato>
         </saldoPerDato>
         <saldoPerDato>
           <beloep>123456</beloep>
-          <dato>2007-08-16+02:00</dato>
+          <dato>2025-05-16</dato>
+        </saldoPerDato>
+      </saldoerPerDato>
+      <laantakereHjemmelshaver>
+        <!--Zero or more repetitions:-->
+        <navn>Kari Nordmann</navn>
+      </laantakereHjemmelshaver>
+    </laan>
+    <laan>
+      <laantakerIkkeHjemmelshaver>true</laantakerIkkeHjemmelshaver>
+      <transporterklaering>false</transporterklaering>
+      <laanenummer>12345678901</laanenummer>
+      <kontonummer>12345678901</kontonummer>
+      <!--Optional:-->
+      <kidnummer>0001234567891</kidnummer>
+      <!--Optional:-->
+      <betalingsmelding>Betaling til innfrielsessaldo</betalingsmelding>
+      <saldoerPerDato>
+        <!--1 or more repetitions:-->
+        <saldoPerDato>
+          <beloep>23123</beloep>
+          <dato>2025-05-17</dato>
+        </saldoPerDato>
+        <saldoPerDato>
+          <beloep>43213</beloep>
+          <dato>2025-05-16</dato>
         </saldoPerDato>
       </saldoerPerDato>
       <laantakereHjemmelshaver>
@@ -76,26 +71,27 @@
     <!--1 or more repetitions:-->
     <registerenhetMedDokumentreferanse>
       <!--You have a CHOICE of the next 3 items at this level-->
-      <matrikkel kommunenavn="Oslo" kommunenummer="0301" gaardsnummer="1" bruksnummer="2" festenummer="3" seksjonsnummer="4" eiendomsnivaa="F"/>
+      <matrikkel kommunenavn="Lillestrøm" kommunenummer="3205" gaardsnummer="273" bruksnummer="220" festenummer="0" seksjonsnummer="12" eiendomsnivaa="E"/>
       <pantedokumentreferanser>
         <!--Zero or more repetitions:-->
-        <pantedokumentreferanse dokumentnummer="3" dokumentaar="1" embetenummer="201" rettsstiftelsesnummer="201" registreringstidspunkt="2017-11-03T04:12:42" beloep="101010"/>
+        <pantedokumentreferanse dokumentnummer="3" dokumentaar="2024" embetenummer="201" rettsstiftelsesnummer="1" registreringstidspunkt="2024-01-10T19:00:47+01:00" beloep="3500000"/>
       </pantedokumentreferanser>
     </registerenhetMedDokumentreferanse>
     <registerenhetMedDokumentreferanse>
       <!--You have a CHOICE of the next 3 items at this level-->
-      <borettsandel organisasjonsnummer="123456789" borettslagnavn="Borettslaget" andelsnummer="1"/>
+      <borettsandel organisasjonsnummer="954442403" borettslagnavn="Feråsen borettslag" andelsnummer="71"/>
       <pantedokumentreferanser>
         <!--Zero or more repetitions:-->
-        <pantedokumentreferanse dokumentnummer="3" dokumentaar="1" embetenummer="201" rettsstiftelsesnummer="201" registreringstidspunkt="2017-11-03T04:12:42" beloep="2010111"/>
+        <pantedokumentreferanse dokumentnummer="3975" dokumentaar="1" embetenummer="201" rettsstiftelsesnummer="201" registreringstidspunkt="2006-11-10T19:00:47+01:00" beloep="201"/>
+        <pantedokumentreferanse dokumentnummer="3" dokumentaar="2024" embetenummer="201" rettsstiftelsesnummer="1" registreringstidspunkt="2024-01-10T19:00:47+01:00" beloep="3500000"/>
       </pantedokumentreferanser>
     </registerenhetMedDokumentreferanse>
     <registerenhetMedDokumentreferanse>
       <!--You have a CHOICE of the next 3 items at this level-->
-      <aksjeleilighet organisasjonsnummer="123456789" organisasjonsnavn="Aksjeselskapet" leilighetsnummer="1"/>
+      <aksjeleilighet organisasjonsnummer="954442403" organisasjonsnavn="Feråsen Akjselag" leilighetsnummer="71"/>
       <pantedokumentreferanser>
         <!--Zero or more repetitions:-->
-        <pantedokumentreferanse dokumentnummer="3" dokumentaar="1" embetenummer="201" rettsstiftelsesnummer="201" registreringstidspunkt="2017-11-03T04:12:42" beloep="13"/>
+        <pantedokumentreferanse dokumentnummer="3" dokumentaar="1" embetenummer="201" rettsstiftelsesnummer="201" registreringstidspunkt="2006-11-10T19:00:47+01:00" beloep="201"/>
       </pantedokumentreferanser>
     </registerenhetMedDokumentreferanse>
   </registerenheterMedDokumentreferanser>

--- a/spesifikasjoner/afpant/afpant-model/examples/innfrielsessaldosvar_1.0.xml
+++ b/spesifikasjoner/afpant/afpant-model/examples/innfrielsessaldosvar_1.0.xml
@@ -61,6 +61,10 @@
           <beloep>1.051732E7</beloep>
           <dato>2007-08-16+02:00</dato>
         </saldoPerDato>
+        <saldoPerDato>
+          <beloep>123456</beloep>
+          <dato>2007-08-16+02:00</dato>
+        </saldoPerDato>
       </saldoerPerDato>
       <laantakereHjemmelshaver>
         <!--Zero or more repetitions:-->

--- a/spesifikasjoner/afpant/afpant-model/examples/innfrielsessaldosvar_1.0.xml
+++ b/spesifikasjoner/afpant/afpant-model/examples/innfrielsessaldosvar_1.0.xml
@@ -1,3 +1,4 @@
+<?xml-stylesheet type="text/xsl" href="../xslt/restgjeld.xslt"?>
 <innfrielsessaldosvar>
   <avsender id="928000000">
     <foretaksnavn>AVSENDER AS</foretaksnavn>

--- a/spesifikasjoner/afpant/afpant-model/examples/restgjeldsforespoersel_1.0.xml
+++ b/spesifikasjoner/afpant/afpant-model/examples/restgjeldsforespoersel_1.0.xml
@@ -1,91 +1,128 @@
 <?xml-stylesheet type="text/xsl" href="../xslt/restgjeld.xslt"?>
 <restgjeldsforespoersel>
-  <avsender id="string">
-    <foretaksnavn>string</foretaksnavn>
+  <avsender id="910968955">
+    <foretaksnavn>DNB EIENDOM AS</foretaksnavn>
     <!--Optional:-->
     <adresse>
       <!--Optional:-->
-      <gatenavn>string</gatenavn>
-      <postnummer>string</postnummer>
-      <poststed>string</poststed>
+      <gatenavn>Dronning Eufemias gate 30</gatenavn>
+      <postnummer>0191</postnummer>
+      <poststed>Oslo</poststed>
     </adresse>
     <!--Optional:-->
     <kontaktperson>
-      <navn>string</navn>
+      <navn>Ole Meglersen</navn>
       <!--Optional:-->
-      <epost>string</epost>
+      <epost>ole.meglersen@dnbeiendom.no</epost>
       <!--Optional:-->
-      <telefondirekte>string</telefondirekte>
+      <telefondirekte>98765432</telefondirekte>
       <!--Optional:-->
-      <telefon>string</telefon>
+      <telefon>22223344</telefon>
     </kontaktperson>
-    <referanse>string</referanse>
+    <referanse>OPGNR-123</referanse>
     <!--Optional:-->
-    <returnertil id="string">
-      <foretaksnavn>string</foretaksnavn>
+    <returnertil id="910968955">
+      <foretaksnavn>DNB EIENDOM (retur) AS</foretaksnavn>
       <!--Optional:-->
       <adresse>
         <!--Optional:-->
-        <gatenavn>string</gatenavn>
-        <postnummer>string</postnummer>
-        <poststed>string</poststed>
+        <gatenavn>Dronning Eufemias gate 32</gatenavn>
+        <postnummer>0191</postnummer>
+        <poststed>Oslo</poststed>
       </adresse>
     </returnertil>
   </avsender>
-  <mottaker id="string">
-    <foretaksnavn>string</foretaksnavn>
-    <!--Optional:-->
-    <adresse>
-      <!--Optional:-->
-      <gatenavn>string</gatenavn>
-      <postnummer>string</postnummer>
-      <poststed>string</poststed>
-    </adresse>
-    <!--Optional:-->
-    <referanse>string</referanse>
+  <mottaker id="984851006">
+    <foretaksnavn>DNB BANK ASA</foretaksnavn>
   </mottaker>
   <registerenheterMedHjemmelshavere>
     <!--1 or more repetitions:-->
     <registerenhetMedHjemmelshavere>
       <!--You have a CHOICE of the next 3 items at this level-->
-      <matrikkel kommunenavn="string" kommunenummer="string" gaardsnummer="string" bruksnummer="string" festenummer="string" seksjonsnummer="string" eiendomsnivaa="F"/>
-      <borettsandel organisasjonsnummer="string" borettslagnavn="string" andelsnummer="string"/>
-      <aksjeleilighet organisasjonsnummer="string" organisasjonsnavn="string" leilighetsnummer="string"/>
+      <matrikkel kommunenavn="Lillestrøm" kommunenummer="3205" gaardsnummer="273" bruksnummer="220" festenummer="0" seksjonsnummer="12" eiendomsnivaa="E"/>
       <hjemmelshavere>
         <!--1 or more repetitions:-->
         <hjemmelshaver>
           <!--You have a CHOICE of the next 2 items at this level-->
-          <organisasjon id="string">
-            <foretaksnavn>string</foretaksnavn>
-            <!--Optional:-->
-            <adresse>
-              <!--Optional:-->
-              <gatenavn>string</gatenavn>
-              <postnummer>string</postnummer>
-              <poststed>string</poststed>
-            </adresse>
+          <person id="17050033455">
+            <fornavn>Ola</fornavn>
+            <etternavn>Normann</etternavn>
+          </person>
+        </hjemmelshaver>
+        <hjemmelshaver>
+          <!--You have a CHOICE of the next 2 items at this level-->
+          <organisasjon id="889693622">
+            <foretaksnavn>SANDSLI EIENDOMSUTVIKLING AS</foretaksnavn>
           </organisasjon>
-          <person id="string">
-            <fornavn>string</fornavn>
-            <etternavn>string</etternavn>
+        </hjemmelshaver>
+        <hjemmelshaver>
+          <!--You have a CHOICE of the next 2 items at this level-->
+          <person id="02027812345">
+            <fornavn>Kari</fornavn>
+            <etternavn>Normann</etternavn>
+          </person>
+        </hjemmelshaver>
+      </hjemmelshavere>
+    </registerenhetMedHjemmelshavere>
+    <registerenhetMedHjemmelshavere>
+      <!--You have a CHOICE of the next 3 items at this level-->
+      <borettsandel organisasjonsnummer="954442403" borettslagnavn="Feråsen borettslag" andelsnummer="71"/>
+      <hjemmelshavere>
+        <!--1 or more repetitions:-->
+        <hjemmelshaver>
+          <!--You have a CHOICE of the next 2 items at this level-->
+          <person id="17050033455">
+            <fornavn>Ola</fornavn>
+            <etternavn>Normann</etternavn>
+          </person>
+        </hjemmelshaver>
+        <hjemmelshaver>
+          <!--You have a CHOICE of the next 2 items at this level-->
+          <organisasjon id="889693622">
+            <foretaksnavn>SANDSLI EIENDOMSUTVIKLING AS</foretaksnavn>
+          </organisasjon>
+        </hjemmelshaver>
+        <hjemmelshaver>
+          <!--You have a CHOICE of the next 2 items at this level-->
+          <person id="02027812345">
+            <fornavn>Kari</fornavn>
+            <etternavn>Normann</etternavn>
+          </person>
+        </hjemmelshaver>
+      </hjemmelshavere>
+    </registerenhetMedHjemmelshavere>
+    <registerenhetMedHjemmelshavere>
+      <!--You have a CHOICE of the next 3 items at this level-->
+      <aksjeleilighet organisasjonsnummer="954442403" organisasjonsnavn="Feråsen Akjselag" leilighetsnummer="71"/>
+      <hjemmelshavere>
+        <!--1 or more repetitions:-->
+        <hjemmelshaver>
+          <!--You have a CHOICE of the next 2 items at this level-->
+          <person id="17050033455">
+            <fornavn>Ola</fornavn>
+            <etternavn>Normann</etternavn>
+          </person>
+        </hjemmelshaver>
+        <hjemmelshaver>
+          <!--You have a CHOICE of the next 2 items at this level-->
+          <organisasjon id="889693622">
+            <foretaksnavn>SANDSLI EIENDOMSUTVIKLING AS</foretaksnavn>
+          </organisasjon>
+        </hjemmelshaver>
+        <hjemmelshaver>
+          <!--You have a CHOICE of the next 2 items at this level-->
+          <person id="02027812345">
+            <fornavn>Kari</fornavn>
+            <etternavn>Normann</etternavn>
           </person>
         </hjemmelshaver>
       </hjemmelshavere>
     </registerenhetMedHjemmelshavere>
   </registerenheterMedHjemmelshavere>
   <!--Optional:-->
-  <prisantydning>201</prisantydning>
+  <prisantydning>20109882</prisantydning>
   <metadata>
     <!--Optional:-->
-    <ressurser>
-      <!--Zero or more repetitions:-->
-      <vedlegg>
-        <navn>string</navn>
-        <mimetype>string</mimetype>
-        <!--Optional:-->
-        <beskrivelse>string</beskrivelse>
-      </vedlegg>
-    </ressurser>
     <opprettet>2009-02-28T21:23:40</opprettet>
   </metadata>
 </restgjeldsforespoersel>

--- a/spesifikasjoner/afpant/afpant-model/examples/restgjeldsforespoersel_1.0.xml
+++ b/spesifikasjoner/afpant/afpant-model/examples/restgjeldsforespoersel_1.0.xml
@@ -1,3 +1,4 @@
+<?xml-stylesheet type="text/xsl" href="../xslt/restgjeld.xslt"?>
 <restgjeldsforespoersel>
   <avsender id="string">
     <foretaksnavn>string</foretaksnavn>

--- a/spesifikasjoner/afpant/afpant-model/examples/restgjeldssvar_1.0.xml
+++ b/spesifikasjoner/afpant/afpant-model/examples/restgjeldssvar_1.0.xml
@@ -64,6 +64,7 @@
         <!--Zero or more repetitions:-->
         <navn>string</navn>
       </laantakereHjemmelshaver>
+      <transporterklaering>true</transporterklaering>
     </laan>
   </laanliste>
   <registerenheterMedDokumentreferanser>

--- a/spesifikasjoner/afpant/afpant-model/examples/restgjeldssvar_1.0.xml
+++ b/spesifikasjoner/afpant/afpant-model/examples/restgjeldssvar_1.0.xml
@@ -81,7 +81,6 @@
     </registerenhetMedDokumentreferanse>
   </registerenheterMedDokumentreferanser>
   <sperretForVidereOpplaan>false</sperretForVidereOpplaan>
-  <bekreftelsePantrettSlettes>false</bekreftelsePantrettSlettes>
   <metadata>
     <!--Optional:-->
     <ressurser>

--- a/spesifikasjoner/afpant/afpant-model/examples/restgjeldssvar_1.0.xml
+++ b/spesifikasjoner/afpant/afpant-model/examples/restgjeldssvar_1.0.xml
@@ -1,3 +1,4 @@
+<?xml-stylesheet type="text/xsl" href="../xslt/restgjeld.xslt"?>
 <restgjeldssvar>
   <avsender id="string">
     <foretaksnavn>string</foretaksnavn>

--- a/spesifikasjoner/afpant/afpant-model/examples/restgjeldssvar_1.0.xml
+++ b/spesifikasjoner/afpant/afpant-model/examples/restgjeldssvar_1.0.xml
@@ -1,86 +1,219 @@
 <?xml-stylesheet type="text/xsl" href="../xslt/restgjeld.xslt"?>
 <restgjeldssvar>
-  <avsender id="string">
-    <foretaksnavn>string</foretaksnavn>
-    <!--Optional:-->
-    <adresse>
-      <!--Optional:-->
-      <gatenavn>string</gatenavn>
-      <postnummer>string</postnummer>
-      <poststed>string</poststed>
-    </adresse>
-    <!--Optional:-->
+  <avsender id="984851006">
+    <foretaksnavn>DNB BANK ASA</foretaksnavn>
     <kontaktperson>
-      <navn>string</navn>
-      <!--Optional:-->
-      <epost>string</epost>
-      <!--Optional:-->
-      <telefondirekte>string</telefondirekte>
-      <!--Optional:-->
-      <telefon>string</telefon>
+      <navn>Ole Bankesen</navn>
+      <epost>ole@dnb.no</epost>
+      <telefondirekte>41414141</telefondirekte>
+      <telefon>22224455</telefon>
     </kontaktperson>
-    <referanse>string</referanse>
-    <!--Optional:-->
-    <returnertil id="string">
-      <foretaksnavn>string</foretaksnavn>
-      <!--Optional:-->
-      <adresse>
-        <!--Optional:-->
-        <gatenavn>string</gatenavn>
-        <postnummer>string</postnummer>
-        <poststed>string</poststed>
-      </adresse>
-    </returnertil>
+    <referanse>FX12398731273123</referanse>
   </avsender>
-  <mottaker id="string">
-    <foretaksnavn>string</foretaksnavn>
-    <!--Optional:-->
-    <adresse>
-      <!--Optional:-->
-      <gatenavn>string</gatenavn>
-      <postnummer>string</postnummer>
-      <poststed>string</poststed>
-    </adresse>
-    <!--Optional:-->
-    <referanse>string</referanse>
+  <mottaker id="910968955">
+    <foretaksnavn>DNB EIENDOM AS</foretaksnavn>
+    <referanse>OPGNR-123</referanse>
   </mottaker>
   <laanliste>
-    <!--1 or more repetitions:-->
+    <!-- lån 1 -->
     <laan>
       <rammelaan>true</rammelaan>
-      <!--Optional:-->
-      <oevreGrenseRammelaan>1.051732E7</oevreGrenseRammelaan>
-      <fastrente>true</fastrente>
+      <oevreGrenseRammelaan>12341234</oevreGrenseRammelaan>
+      <fastrente>false</fastrente>
       <realkausjon>false</realkausjon>
       <laantakerIkkeHjemmelshaver>true</laantakerIkkeHjemmelshaver>
-      <laanenummer>string</laanenummer>
-      <kontonummer>string</kontonummer>
+      <transporterklaering>false</transporterklaering>
+      <laanenummer>12342133341</laanenummer>
+      <kontonummer>46012133341</kontonummer>
       <!--Optional:-->
-      <kidnummer>string</kidnummer>
+      <kidnummer>0000001231231</kidnummer>
       <!--Optional:-->
-      <betalingsmelding>string</betalingsmelding>
-      <saldo>1000.00</saldo>
+      <betalingsmelding>Betalingsmelding</betalingsmelding>
+      <saldo>1000.20</saldo>
       <laantakereHjemmelshaver>
         <!--Zero or more repetitions:-->
-        <navn>string</navn>
+        <navn>Ola</navn>
+        <navn>Kari</navn>
+        <navn>SANDSLI EIENDOMSUTVIKLING AS</navn>
       </laantakereHjemmelshaver>
+    </laan>
+    <!-- lån 2 -->
+    <laan>
+      <rammelaan>false</rammelaan>
+      <fastrente>true</fastrente>
+      <realkausjon>true</realkausjon>
+      <laantakerIkkeHjemmelshaver>true</laantakerIkkeHjemmelshaver>
+      <transporterklaering>false</transporterklaering>
+      <laanenummer>12342133342</laanenummer>
+      <kontonummer>46012133342</kontonummer>
+      <!--Optional:-->
+      <kidnummer>0000001231231</kidnummer>
+      <!--Optional:-->
+      <betalingsmelding>Betalingsmelding</betalingsmelding>
+      <saldo>1000.20</saldo>
+      <laantakereHjemmelshaver>
+        <!--Zero or more repetitions:-->
+        <navn>Ola</navn>
+        <navn>Kari</navn>
+        <navn>SANDSLI EIENDOMSUTVIKLING AS</navn>
+      </laantakereHjemmelshaver>
+    </laan>
+    <!-- lån 3 -->
+    <laan>
+      <rammelaan>false</rammelaan>
+      <fastrente>false</fastrente>
+      <realkausjon>true</realkausjon>
+      <laantakerIkkeHjemmelshaver>false</laantakerIkkeHjemmelshaver>
       <transporterklaering>true</transporterklaering>
+      <laanenummer>12342133343</laanenummer>
+      <kontonummer>46012133343</kontonummer>
+      <!--Optional:-->
+      <kidnummer>0000001231231</kidnummer>
+      <!--Optional:-->
+      <betalingsmelding>Betalingsmelding</betalingsmelding>
+      <saldo>1000.20</saldo>
+      <laantakereHjemmelshaver>
+        <!--Zero or more repetitions:-->
+        <navn>Ola</navn>
+        <navn>Kari</navn>
+        <navn>SANDSLI EIENDOMSUTVIKLING AS</navn>
+      </laantakereHjemmelshaver>
+    </laan>
+    <laan>
+      <rammelaan>true</rammelaan>
+      <oevreGrenseRammelaan>12341234</oevreGrenseRammelaan>
+      <fastrente>false</fastrente>
+      <realkausjon>false</realkausjon>
+      <laantakerIkkeHjemmelshaver>true</laantakerIkkeHjemmelshaver>
+      <transporterklaering>false</transporterklaering>
+      <laanenummer>12342133345</laanenummer>
+      <kontonummer>46012133345</kontonummer>
+      <!--Optional:-->
+      <kidnummer>0000001231231</kidnummer>
+      <!--Optional:-->
+      <betalingsmelding>Betalingsmelding</betalingsmelding>
+      <saldo>1000.20</saldo>
+      <laantakereHjemmelshaver>
+        <!--Zero or more repetitions:-->
+        <navn>Ola</navn>
+        <navn>Kari</navn>
+        <navn>SANDSLI EIENDOMSUTVIKLING AS</navn>
+      </laantakereHjemmelshaver>
+    </laan>
+    <laan>
+      <rammelaan>true</rammelaan>
+      <oevreGrenseRammelaan>12341234</oevreGrenseRammelaan>
+      <fastrente>false</fastrente>
+      <realkausjon>false</realkausjon>
+      <laantakerIkkeHjemmelshaver>true</laantakerIkkeHjemmelshaver>
+      <transporterklaering>false</transporterklaering>
+      <laanenummer>12342133345</laanenummer>
+      <kontonummer>46012133345</kontonummer>
+      <!--Optional:-->
+      <kidnummer>0000001231231</kidnummer>
+      <!--Optional:-->
+      <betalingsmelding>Betalingsmelding</betalingsmelding>
+      <saldo>1000.20</saldo>
+      <laantakereHjemmelshaver>
+        <!--Zero or more repetitions:-->
+        <navn>Ola</navn>
+        <navn>Kari</navn>
+        <navn>SANDSLI EIENDOMSUTVIKLING AS</navn>
+      </laantakereHjemmelshaver>
+    </laan>
+    <laan>
+      <rammelaan>true</rammelaan>
+      <oevreGrenseRammelaan>12341234</oevreGrenseRammelaan>
+      <fastrente>false</fastrente>
+      <realkausjon>false</realkausjon>
+      <laantakerIkkeHjemmelshaver>true</laantakerIkkeHjemmelshaver>
+      <transporterklaering>false</transporterklaering>
+      <laanenummer>12342133345</laanenummer>
+      <kontonummer>46012133345</kontonummer>
+      <!--Optional:-->
+      <kidnummer>0000001231231</kidnummer>
+      <!--Optional:-->
+      <betalingsmelding>Betalingsmelding</betalingsmelding>
+      <saldo>1000.20</saldo>
+      <laantakereHjemmelshaver>
+        <!--Zero or more repetitions:-->
+        <navn>Ola</navn>
+        <navn>Kari</navn>
+        <navn>SANDSLI EIENDOMSUTVIKLING AS</navn>
+      </laantakereHjemmelshaver>
+    </laan>
+    <laan>
+      <rammelaan>true</rammelaan>
+      <oevreGrenseRammelaan>12341234</oevreGrenseRammelaan>
+      <fastrente>false</fastrente>
+      <realkausjon>false</realkausjon>
+      <laantakerIkkeHjemmelshaver>true</laantakerIkkeHjemmelshaver>
+      <transporterklaering>false</transporterklaering>
+      <laanenummer>12342133345</laanenummer>
+      <kontonummer>46012133345</kontonummer>
+      <!--Optional:-->
+      <kidnummer>0000001231231</kidnummer>
+      <!--Optional:-->
+      <betalingsmelding>Betalingsmelding</betalingsmelding>
+      <saldo>1000.20</saldo>
+      <laantakereHjemmelshaver>
+        <!--Zero or more repetitions:-->
+        <navn>Ola</navn>
+        <navn>Kari</navn>
+        <navn>SANDSLI EIENDOMSUTVIKLING AS</navn>
+      </laantakereHjemmelshaver>
+    </laan>
+    <laan>
+      <rammelaan>true</rammelaan>
+      <oevreGrenseRammelaan>12341234</oevreGrenseRammelaan>
+      <fastrente>false</fastrente>
+      <realkausjon>false</realkausjon>
+      <laantakerIkkeHjemmelshaver>true</laantakerIkkeHjemmelshaver>
+      <transporterklaering>false</transporterklaering>
+      <laanenummer>12342133345</laanenummer>
+      <kontonummer>46012133345</kontonummer>
+      <!--Optional:-->
+      <kidnummer>0000001231231</kidnummer>
+      <!--Optional:-->
+      <betalingsmelding>Betalingsmelding</betalingsmelding>
+      <saldo>1000.20</saldo>
+      <laantakereHjemmelshaver>
+        <!--Zero or more repetitions:-->
+        <navn>Ola</navn>
+        <navn>Kari</navn>
+        <navn>SANDSLI EIENDOMSUTVIKLING AS</navn>
+      </laantakereHjemmelshaver>
     </laan>
   </laanliste>
   <registerenheterMedDokumentreferanser>
     <!--1 or more repetitions:-->
     <registerenhetMedDokumentreferanse>
       <!--You have a CHOICE of the next 3 items at this level-->
-      <matrikkel kommunenavn="string" kommunenummer="string" gaardsnummer="string" bruksnummer="string" festenummer="string" seksjonsnummer="string" eiendomsnivaa="F_1"/>
-      <borettsandel organisasjonsnummer="string" borettslagnavn="string" andelsnummer="string"/>
-      <aksjeleilighet organisasjonsnummer="string" organisasjonsnavn="string" leilighetsnummer="string"/>
+      <matrikkel kommunenavn="Lillestrøm" kommunenummer="3205" gaardsnummer="273" bruksnummer="220" festenummer="0" seksjonsnummer="12" eiendomsnivaa="E"/>
+      <pantedokumentreferanser>
+        <!--Zero or more repetitions:-->
+        <pantedokumentreferanse dokumentnummer="3" dokumentaar="2024" embetenummer="201" rettsstiftelsesnummer="1" registreringstidspunkt="2024-01-10T19:00:47+01:00" beloep="3500000"/>
+      </pantedokumentreferanser>
+    </registerenhetMedDokumentreferanse>
+    <registerenhetMedDokumentreferanse>
+      <!--You have a CHOICE of the next 3 items at this level-->
+      <borettsandel organisasjonsnummer="954442403" borettslagnavn="Feråsen borettslag" andelsnummer="71"/>
+      <pantedokumentreferanser>
+        <!--Zero or more repetitions:-->
+        <pantedokumentreferanse dokumentnummer="3975" dokumentaar="1" embetenummer="201" rettsstiftelsesnummer="201" registreringstidspunkt="2006-11-10T19:00:47+01:00" beloep="201"/>
+        <pantedokumentreferanse dokumentnummer="3" dokumentaar="2024" embetenummer="201" rettsstiftelsesnummer="1" registreringstidspunkt="2024-01-10T19:00:47+01:00" beloep="3500000"/>
+      </pantedokumentreferanser>
+    </registerenhetMedDokumentreferanse>
+    <registerenhetMedDokumentreferanse>
+      <!--You have a CHOICE of the next 3 items at this level-->
+      <aksjeleilighet organisasjonsnummer="954442403" organisasjonsnavn="Feråsen Akjselag" leilighetsnummer="71"/>
       <pantedokumentreferanser>
         <!--Zero or more repetitions:-->
         <pantedokumentreferanse dokumentnummer="3" dokumentaar="1" embetenummer="201" rettsstiftelsesnummer="201" registreringstidspunkt="2006-11-10T19:00:47+01:00" beloep="201"/>
       </pantedokumentreferanser>
     </registerenhetMedDokumentreferanse>
   </registerenheterMedDokumentreferanser>
-  <sperretForVidereOpplaan>false</sperretForVidereOpplaan>
+  <sperretForVidereOpplaan>true</sperretForVidereOpplaan>
   <metadata>
     <!--Optional:-->
     <ressurser>

--- a/spesifikasjoner/afpant/afpant-model/xslt/dsve.xslt
+++ b/spesifikasjoner/afpant/afpant-model/xslt/dsve.xslt
@@ -844,7 +844,7 @@
       <xsl:value-of select="$matrikkel/@bruksnummer"/>
       <!-- Siden XSD sier at seksjonsnummer / festenummer er optional tester vi også mot tom streng (PH) -->
       <xsl:if test="not($matrikkel/@seksjonsnummer = '0') and not($matrikkel/@seksjonsnummer = '')">
-        <xsl:text>,&#x20;sekjsonsnr.:&#x20;</xsl:text>
+        <xsl:text>,&#x20;seksjonsnr.:&#x20;</xsl:text>
         <xsl:value-of select="$matrikkel/@seksjonsnummer"/>
       </xsl:if>
       <xsl:if test="not($matrikkel/@festenummer = '0') and not($matrikkel/@festenummer = '')">

--- a/spesifikasjoner/afpant/afpant-model/xslt/kjopekontrakt.xslt
+++ b/spesifikasjoner/afpant/afpant-model/xslt/kjopekontrakt.xslt
@@ -699,7 +699,7 @@
       <xsl:value-of select="$matrikkel/@bruksnummer"/>
       <!-- Siden XSD sier at seksjonsnummer / festenummer er optional tester vi også mot tom streng (PH) -->
       <xsl:if test="not($matrikkel/@seksjonsnummer = '0') and not($matrikkel/@seksjonsnummer = '')">
-        <xsl:text>,&#x20;sekjsonsnr.:&#x20;</xsl:text>
+        <xsl:text>,&#x20;seksjonsnr.:&#x20;</xsl:text>
         <xsl:value-of select="$matrikkel/@seksjonsnummer"/>
       </xsl:if>
       <xsl:if test="not($matrikkel/@festenummer = '0') and not($matrikkel/@festenummer = '')">

--- a/spesifikasjoner/afpant/afpant-model/xslt/restgjeld.xslt
+++ b/spesifikasjoner/afpant/afpant-model/xslt/restgjeld.xslt
@@ -202,7 +202,6 @@
         </xsl:call-template>
         <xsl:call-template name="laan"/>
         <xsl:apply-templates select="sperretForVidereOpplaan"/>
-        <xsl:apply-templates select="bekreftelsePantrettSlettes"/>
         <xsl:call-template name="ressurser"/>
         <xsl:call-template name="avsender"/>
         <hr/>
@@ -346,18 +345,6 @@
         <div class="hovedseksjon">
             <xsl:call-template name="seksjon">
                 <xsl:with-param name="tittel" select="'Sperret for videre opplån'"/>
-            </xsl:call-template>
-            <div class="innhold">
-                <xsl:call-template name="yesNo">
-                    <xsl:with-param name="booleanValue" select="."/>
-                </xsl:call-template>
-            </div>
-        </div>
-    </xsl:template>
-    <xsl:template match="bekreftelsePantrettSlettes">
-        <div class="hovedseksjon">
-            <xsl:call-template name="seksjon">
-                <xsl:with-param name="tittel" select="'Bekreftelse pantrett slettes'"/>
             </xsl:call-template>
             <div class="innhold">
                 <xsl:call-template name="yesNo">

--- a/spesifikasjoner/afpant/afpant-model/xslt/restgjeld.xslt
+++ b/spesifikasjoner/afpant/afpant-model/xslt/restgjeld.xslt
@@ -1,0 +1,485 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+    <xsl:output method="html" encoding="utf-8" indent="yes" omit-xml-declaration="yes"/>
+    <xsl:decimal-format name="nb-no-space" decimal-separator="," grouping-separator=" " NaN=" "/>
+    
+    <!-- Root template -->
+    <xsl:template match="/">
+        <html>
+            <head>
+                <title>
+                    <xsl:call-template name="get-title"/>
+                </title>
+                <style type="text/css">
+                    .rolleoverskrift,
+                    .seksjonsoverskrift {
+                        font-weight: 500;
+                        color: #255473
+                    }
+
+                    #footer,
+                    .overskrift,
+                    .rolleoverskrift {
+                        color: #255473
+                    }
+
+                    .seksjonsoverskrift {
+                        padding-bottom: 8px
+                    }
+
+                    .rolleoverskrift {
+                        padding-top: 8px
+                    }
+
+                    .listeelement {
+                        font-weight: 400;
+                        padding-bottom: 4px
+                    }
+
+                    .innhold {
+                        padding-left: 8px
+                    }
+
+                    body {
+                        margin: 0;
+                        padding: 0;
+                        height: 100%
+                    }
+
+                    .hovedseksjon {
+                        padding: 5px;
+                        margin-bottom: 4px
+                    }
+
+                    #container {
+                        min-height: 100%;
+                        position: relative;
+                        margin: 10px;
+                        font-family: helvetica;
+                        max-width: 210mm
+                    }
+
+                    #header {
+                        padding-left: 5px;
+                        padding-top: 1px;
+                        padding-bottom: 1px
+                    }
+
+                    #body {
+                        padding-top: 10px;
+                        padding-bottom: 50px;
+                        width: 100%
+                    }
+
+                    .tabell {
+                        display: table;
+                        padding-bottom: 4px;
+                        width: 100%;
+                        table-layout: fixed
+                    }
+
+                    .rad {
+                        display: table-row
+                    }
+
+                    .celle {
+                        border: 0;
+                        display: table-cell;
+                        padding: 1px
+                    }
+
+                    .kropp {
+                        display: table-row-group
+                    }
+
+                    .kol1 {
+                        min-width: 80px;
+                        width: 350px
+                    }
+
+                    .kol2 {
+                        width: 120px
+                    }
+
+                    .headerrad {
+                        color: grey;
+                        font-size: 11px
+                    }
+
+                    .tall {
+                        text-align: right;
+                    }
+                </style>
+            </head>
+            <body>
+                <div id="container">
+                    <div id="header">
+                        <h1 class="overskrift">
+                            <xsl:call-template name="get-title"/>
+                        </h1>
+                        <hr/>
+                    </div>
+                    <div id="body">
+                        <xsl:apply-templates select="innfrielsessaldoforespoersel"/>
+                        <xsl:apply-templates select="innfrielsessaldosvar"/>
+                    </div>
+                </div>
+            </body>
+        </html>
+    </xsl:template>
+
+    <!-- Title helper template -->
+    <xsl:template name="get-title">
+        <xsl:choose>
+            <xsl:when test="innfrielsessaldoforespoersel">Forespørsel om innfrielsessaldo</xsl:when>
+            <xsl:when test="innfrielsessaldosvar">Svar på innfrielsessaldo</xsl:when>
+        </xsl:choose>
+    </xsl:template>
+
+    <!-- Innfrielsessaldosvar template -->
+    <xsl:template match="innfrielsessaldosvar">
+        <!-- Avsender section -->
+        <div class="hovedseksjon">
+            <div class="seksjonsoverskrift">Avsender</div>
+            <div class="tabell innhold">
+                <div class="kropp">
+                    <xsl:apply-templates select="avsender"/>
+                </div>
+            </div>
+        </div>
+
+        <!-- Mottaker section -->
+        <div class="hovedseksjon">
+            <div class="seksjonsoverskrift">Mottaker</div>
+            <div class="tabell innhold">
+                <div class="kropp">
+                    <xsl:apply-templates select="mottaker"/>
+                </div>
+            </div>
+        </div>
+
+        <!-- Lån section -->
+        <div class="hovedseksjon">
+            <div class="seksjonsoverskrift">Lån</div>
+            <div class="tabell innhold">
+                <div class="kropp">
+                    <xsl:apply-templates select="laanliste/laan"/>
+                </div>
+            </div>
+        </div>
+
+        <!-- Registerenheter section -->
+        <div class="hovedseksjon">
+            <div class="seksjonsoverskrift">Registerenheter med dokumentreferanser</div>
+            <div class="tabell innhold">
+                <div class="kropp">
+                    <xsl:apply-templates select="registerenheterMedDokumentreferanser/registerenhetMedDokumentreferanse"/>
+                </div>
+            </div>
+        </div>
+    </xsl:template>
+
+    <!-- Innfrielsessaldoforespoersel template -->
+    <xsl:template match="innfrielsessaldoforespoersel">
+        <!-- Avsender section -->
+        <div class="hovedseksjon">
+            <div class="seksjonsoverskrift">Avsender</div>
+            <div class="tabell innhold">
+                <div class="kropp">
+                    <xsl:apply-templates select="avsender"/>
+                </div>
+            </div>
+        </div>
+
+        <!-- Mottaker section -->
+        <div class="hovedseksjon">
+            <div class="seksjonsoverskrift">Mottaker</div>
+            <div class="tabell innhold">
+                <div class="kropp">
+                    <xsl:apply-templates select="mottaker"/>
+                </div>
+            </div>
+        </div>
+
+        <!-- Registerenheter section -->
+        <div class="hovedseksjon">
+            <div class="seksjonsoverskrift">Registerenheter med Hjemmelshavere</div>
+            <div class="tabell innhold">
+                <div class="kropp">
+                    <xsl:apply-templates select="registerenheterMedHjemmelshavere"/>
+                </div>
+            </div>
+        </div>
+
+        <!-- Innfrielsesdatoer section -->
+        <div class="hovedseksjon">
+            <div class="seksjonsoverskrift">Innfrielsesdatoer</div>
+            <div class="tabell innhold">
+                <div class="kropp">
+                    <xsl:apply-templates select="innfrielsesdatoer"/>
+                </div>
+            </div>
+        </div>
+    </xsl:template>
+
+    <!-- Lån template -->
+    <xsl:template match="laan">
+        <div class="rad">
+            <div class="celle">
+                <div>Lånenummer: <xsl:value-of select="laanenummer"/></div>
+                <div>Kontonummer: <xsl:value-of select="kontonummer"/></div>
+                <xsl:if test="kidnummer">
+                    <div>KID: <xsl:value-of select="kidnummer"/></div>
+                </xsl:if>
+                <xsl:if test="betalingsmelding">
+                    <div>Betalingsmelding: <xsl:value-of select="betalingsmelding"/></div>
+                </xsl:if>
+                
+                <div class="rolleoverskrift">Saldoer per dato</div>
+                <xsl:for-each select="saldoerPerDato/saldoPerDato">
+                    <div class="innhold">
+                        <xsl:call-template name="formatNumber">
+                            <xsl:with-param name="prefix" select="'NOK '"/>
+                            <xsl:with-param name="numericValue" select="beloep"/>
+                        </xsl:call-template>
+                        <xsl:text> per </xsl:text>
+                        <xsl:call-template name="format-date">
+                            <xsl:with-param name="date" select="dato"/>
+                        </xsl:call-template>
+                    </div>
+                </xsl:for-each>
+
+                <xsl:if test="laantakereHjemmelshaver/navn">
+                    <div class="rolleoverskrift">Låntakere som er hjemmelshavere</div>
+                    <xsl:for-each select="laantakereHjemmelshaver/navn">
+                        <div class="innhold"><xsl:value-of select="."/></div>
+                    </xsl:for-each>
+                </xsl:if>
+            </div>
+        </div>
+    </xsl:template>
+
+    <!-- Registerenhet med dokumentreferanse template -->
+    <xsl:template match="registerenhetMedDokumentreferanse">
+        <div class="rad">
+            <div class="celle">
+                <xsl:choose>
+                    <xsl:when test="matrikkel">
+                        <div>Matrikkel:</div>
+                        <div class="innhold">
+                            Kommune: <xsl:value-of select="matrikkel/@kommunenavn"/> (<xsl:value-of select="matrikkel/@kommunenummer"/>)<br/>
+                            Gårdsnr: <xsl:value-of select="matrikkel/@gaardsnummer"/><br/>
+                            Bruksnr: <xsl:value-of select="matrikkel/@bruksnummer"/>
+                            <xsl:if test="matrikkel/@festenummer">
+                                <br/>Festenr: <xsl:value-of select="matrikkel/@festenummer"/>
+                            </xsl:if>
+                            <xsl:if test="matrikkel/@seksjonsnummer">
+                                <br/>Seksjonsnr: <xsl:value-of select="matrikkel/@seksjonsnummer"/>
+                            </xsl:if>
+                        </div>
+                    </xsl:when>
+                    <xsl:when test="borettsandel">
+                        <div>Borettsandel:</div>
+                        <div class="innhold">
+                            Borettslag: <xsl:value-of select="borettsandel/@borettslagnavn"/><br/>
+                            Org.nr: <xsl:value-of select="borettsandel/@organisasjonsnummer"/><br/>
+                            Andelsnr: <xsl:value-of select="borettsandel/@andelsnummer"/>
+                        </div>
+                    </xsl:when>
+                    <xsl:when test="aksjeleilighet">
+                        <div>Aksjeleilighet:</div>
+                        <div class="innhold">
+                            Selskap: <xsl:value-of select="aksjeleilighet/@organisasjonsnavn"/><br/>
+                            Org.nr: <xsl:value-of select="aksjeleilighet/@organisasjonsnummer"/><br/>
+                            Leilighetsnr: <xsl:value-of select="aksjeleilighet/@leilighetsnummer"/>
+                        </div>
+                    </xsl:when>
+                </xsl:choose>
+
+                <xsl:if test="pantedokumentreferanser/pantedokumentreferanse">
+                    <div class="rolleoverskrift">Pantedokumentreferanser</div>
+                    <xsl:for-each select="pantedokumentreferanser/pantedokumentreferanse">
+                        <div class="innhold">
+                            Dokumentnr: <xsl:value-of select="@dokumentnummer"/>/<xsl:value-of select="@dokumentaar"/><br/>
+                            Embete: <xsl:value-of select="@embetenummer"/><br/>
+                            Rettsstiftelse: <xsl:value-of select="@rettsstiftelsesnummer"/><br/>
+                            Registrert: <xsl:call-template name="format-datetime">
+                                <xsl:with-param name="datetime" select="@registreringstidspunkt"/>
+                            </xsl:call-template><br/>
+                            Beløp: <xsl:call-template name="formatNumber">
+                                <xsl:with-param name="prefix" select="'NOK '"/>
+                                <xsl:with-param name="numericValue" select="@beloep"/>
+                            </xsl:call-template>
+                        </div>
+                    </xsl:for-each>
+                </xsl:if>
+            </div>
+        </div>
+    </xsl:template>
+
+    <!-- Helper template for formatting dates -->
+    <xsl:template name="format-date">
+        <xsl:param name="date"/>
+        <xsl:value-of select="substring($date, 9, 2)"/>.<xsl:value-of select="substring($date, 6, 2)"/>.<xsl:value-of select="substring($date, 1, 4)"/>
+    </xsl:template>
+
+    <!-- Helper template for formatting date-times -->
+    <xsl:template name="format-datetime">
+        <xsl:param name="datetime"/>
+        <xsl:value-of select="substring($datetime, 9, 2)"/>.<xsl:value-of select="substring($datetime, 6, 2)"/>.<xsl:value-of select="substring($datetime, 1, 4)"/>
+        <xsl:text> </xsl:text>
+        <xsl:value-of select="substring($datetime, 12, 5)"/>
+    </xsl:template>
+
+    <!-- Helper template for formatting numbers -->
+    <xsl:template name="formatNumber">
+        <xsl:param name="prefix"/>
+        <xsl:param name="numericValue"/>
+        <xsl:if test="string-length($prefix) &gt; 0">
+            <xsl:value-of select="$prefix"/>
+        </xsl:if>
+        <xsl:value-of select="format-number(number($numericValue), '### ### ### ###', 'nb-no-space')"/>
+    </xsl:template>
+
+    <!-- Avsender template -->
+    <xsl:template match="avsender">
+        <div class="rad">
+            <div class="celle kol1">
+                <xsl:value-of select="foretaksnavn"/>
+                <xsl:if test="@id">
+                    <xsl:text> (</xsl:text>
+                    <xsl:value-of select="@id"/>
+                    <xsl:text>)</xsl:text>
+                </xsl:if>
+            </div>
+        </div>
+        <xsl:if test="adresse">
+            <div class="rad">
+                <div class="celle">
+                    <xsl:value-of select="adresse/gatenavn"/>,
+                    <xsl:value-of select="adresse/postnummer"/>
+                    <xsl:text> </xsl:text>
+                    <xsl:value-of select="adresse/poststed"/>
+                </div>
+            </div>
+        </xsl:if>
+        <xsl:if test="kontaktperson">
+            <div class="rad">
+                <div class="celle">
+                    <div><xsl:value-of select="kontaktperson/navn"/></div>
+                    <xsl:if test="kontaktperson/epost">
+                        <div><a href="mailto:{kontaktperson/epost}"><xsl:value-of select="kontaktperson/epost"/></a></div>
+                    </xsl:if>
+                    <xsl:if test="kontaktperson/telefon">
+                        <div>Tlf: <a href="tel:{kontaktperson/telefon}"><xsl:value-of select="kontaktperson/telefon"/></a></div>
+                    </xsl:if>
+                </div>
+            </div>
+        </xsl:if>
+    </xsl:template>
+
+    <!-- Mottaker template -->
+    <xsl:template match="mottaker">
+        <div class="rad">
+            <div class="celle kol1">
+                <xsl:value-of select="foretaksnavn"/>
+                <xsl:if test="@id">
+                    <xsl:text> (</xsl:text>
+                    <xsl:value-of select="@id"/>
+                    <xsl:text>)</xsl:text>
+                </xsl:if>
+            </div>
+        </div>
+        <xsl:if test="adresse">
+            <div class="rad">
+                <div class="celle">
+                    <xsl:value-of select="adresse/gatenavn"/>,
+                    <xsl:value-of select="adresse/postnummer"/>
+                    <xsl:text> </xsl:text>
+                    <xsl:value-of select="adresse/poststed"/>
+                </div>
+            </div>
+        </xsl:if>
+    </xsl:template>
+
+    <!-- Registerenheter template -->
+    <xsl:template match="registerenheterMedHjemmelshavere">
+        <xsl:for-each select="registerenhetMedHjemmelshavere">
+            <div class="rad">
+                <div class="celle">
+                    <xsl:choose>
+                        <xsl:when test="matrikkel">
+                            <div>Matrikkel:</div>
+                            <div class="innhold">
+                                Kommune: <xsl:value-of select="matrikkel/@kommunenavn"/> (<xsl:value-of select="matrikkel/@kommunenummer"/>)<br/>
+                                Gårdsnr: <xsl:value-of select="matrikkel/@gaardsnummer"/><br/>
+                                Bruksnr: <xsl:value-of select="matrikkel/@bruksnummer"/>
+                                <xsl:if test="matrikkel/@festenummer">
+                                    <br/>Festenr: <xsl:value-of select="matrikkel/@festenummer"/>
+                                </xsl:if>
+                                <xsl:if test="matrikkel/@seksjonsnummer">
+                                    <br/>Seksjonsnr: <xsl:value-of select="matrikkel/@seksjonsnummer"/>
+                                </xsl:if>
+                            </div>
+                        </xsl:when>
+                        <xsl:when test="borettsandel">
+                            <div>Borettsandel:</div>
+                            <div class="innhold">
+                                Borettslag: <xsl:value-of select="borettsandel/@borettslagnavn"/><br/>
+                                Org.nr: <xsl:value-of select="borettsandel/@organisasjonsnummer"/><br/>
+                                Andelsnr: <xsl:value-of select="borettsandel/@andelsnummer"/>
+                            </div>
+                        </xsl:when>
+                        <xsl:when test="aksjeleilighet">
+                            <div>Aksjeleilighet:</div>
+                            <div class="innhold">
+                                Selskap: <xsl:value-of select="aksjeleilighet/@organisasjonsnavn"/><br/>
+                                Org.nr: <xsl:value-of select="aksjeleilighet/@organisasjonsnummer"/><br/>
+                                Leilighetsnr: <xsl:value-of select="aksjeleilighet/@leilighetsnummer"/>
+                            </div>
+                        </xsl:when>
+                    </xsl:choose>
+                </div>
+            </div>
+            <xsl:if test="hjemmelshavere">
+                <div class="rad">
+                    <div class="celle">
+                        <div class="rolleoverskrift">Hjemmelshavere</div>
+                        <xsl:for-each select="hjemmelshavere/hjemmelshaver">
+                            <div class="innhold">
+                                <xsl:choose>
+                                    <xsl:when test="person">
+                                        <xsl:value-of select="person/fornavn"/>
+                                        <xsl:text> </xsl:text>
+                                        <xsl:value-of select="person/etternavn"/>
+                                        <xsl:text> (</xsl:text>
+                                        <xsl:value-of select="person/@id"/>
+                                        <xsl:text>)</xsl:text>
+                                    </xsl:when>
+                                    <xsl:when test="organisasjon">
+                                        <xsl:value-of select="organisasjon/foretaksnavn"/>
+                                        <xsl:text> (</xsl:text>
+                                        <xsl:value-of select="organisasjon/@id"/>
+                                        <xsl:text>)</xsl:text>
+                                    </xsl:when>
+                                </xsl:choose>
+                            </div>
+                        </xsl:for-each>
+                    </div>
+                </div>
+            </xsl:if>
+        </xsl:for-each>
+    </xsl:template>
+
+    <!-- Innfrielsesdatoer template -->
+    <xsl:template match="innfrielsesdatoer">
+        <xsl:for-each select="innfrielsesdato">
+            <div class="rad">
+                <div class="celle">
+                    <xsl:value-of select="."/>
+                </div>
+            </div>
+        </xsl:for-each>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/spesifikasjoner/afpant/afpant-model/xslt/restgjeld.xslt
+++ b/spesifikasjoner/afpant/afpant-model/xslt/restgjeld.xslt
@@ -281,18 +281,9 @@
             <div class="celle">
                 <xsl:choose>
                     <xsl:when test="matrikkel">
-                        <div>Matrikkel:</div>
-                        <div class="innhold">
-                            Kommune: <xsl:value-of select="matrikkel/@kommunenavn"/> (<xsl:value-of select="matrikkel/@kommunenummer"/>)<br/>
-                            Gårdsnr: <xsl:value-of select="matrikkel/@gaardsnummer"/><br/>
-                            Bruksnr: <xsl:value-of select="matrikkel/@bruksnummer"/>
-                            <xsl:if test="matrikkel/@festenummer">
-                                <br/>Festenr: <xsl:value-of select="matrikkel/@festenummer"/>
-                            </xsl:if>
-                            <xsl:if test="matrikkel/@seksjonsnummer">
-                                <br/>Seksjonsnr: <xsl:value-of select="matrikkel/@seksjonsnummer"/>
-                            </xsl:if>
-                        </div>
+                        <xsl:call-template name="matrikkel">
+                            <xsl:with-param name="matrikkel" select="matrikkel"/>
+                        </xsl:call-template>    
                     </xsl:when>
                     <xsl:when test="borettsandel">
                         <div>Borettsandel:</div>
@@ -450,18 +441,9 @@
                 <div class="celle">
                     <xsl:choose>
                         <xsl:when test="matrikkel">
-                            <div>Matrikkel:</div>
-                            <div class="innhold">
-                                Kommune: <xsl:value-of select="matrikkel/@kommunenavn"/> (<xsl:value-of select="matrikkel/@kommunenummer"/>)<br/>
-                                Gårdsnr: <xsl:value-of select="matrikkel/@gaardsnummer"/><br/>
-                                Bruksnr: <xsl:value-of select="matrikkel/@bruksnummer"/>
-                                <xsl:if test="matrikkel/@festenummer">
-                                    <br/>Festenr: <xsl:value-of select="matrikkel/@festenummer"/>
-                                </xsl:if>
-                                <xsl:if test="matrikkel/@seksjonsnummer">
-                                    <br/>Seksjonsnr: <xsl:value-of select="matrikkel/@seksjonsnummer"/>
-                                </xsl:if>
-                            </div>
+                            <xsl:call-template name="matrikkel">
+                                <xsl:with-param name="matrikkel" select="matrikkel"/>
+                            </xsl:call-template>
                         </xsl:when>
                         <xsl:when test="borettsandel">
                             <div>Borettsandel:</div>
@@ -521,6 +503,29 @@
                 </div>
             </div>
         </xsl:for-each>
+    </xsl:template>
+
+    <xsl:template name="matrikkel">
+        <xsl:param name="matrikkel"/>
+        <div>
+        <xsl:text>Kommune:&#x20;</xsl:text>
+        <xsl:value-of select="$matrikkel/@kommunenavn"/>
+        <xsl:text>&#x20;</xsl:text>
+        <xsl:value-of select="$matrikkel/@kommunenummer"/>
+        <xsl:text>,&#x20;gårdsnr.:&#x20;</xsl:text>
+        <xsl:value-of select="$matrikkel/@gaardsnummer"/>
+        <xsl:text>,&#x20;bruksnr.:&#x20;</xsl:text>
+        <xsl:value-of select="$matrikkel/@bruksnummer"/>
+        <!-- Siden XSD sier at seksjonsnummer / festenummer er optional tester vi også mot tom streng (PH) -->
+        <xsl:if test="not($matrikkel/@seksjonsnummer = '0') and not($matrikkel/@seksjonsnummer = '')">
+            <xsl:text>,&#x20;sekjsonsnr.:&#x20;</xsl:text>
+            <xsl:value-of select="$matrikkel/@seksjonsnummer"/>
+        </xsl:if>
+        <xsl:if test="not($matrikkel/@festenummer = '0') and not($matrikkel/@festenummer = '')">
+            <xsl:text>,&#x20;festenr.:&#x20;</xsl:text>
+            <xsl:value-of select="$matrikkel/@festenummer"/>
+        </xsl:if>
+        </div>
     </xsl:template>
 
 </xsl:stylesheet>

--- a/spesifikasjoner/afpant/afpant-model/xslt/restgjeld.xslt
+++ b/spesifikasjoner/afpant/afpant-model/xslt/restgjeld.xslt
@@ -135,6 +135,7 @@
                     <div id="body">
                         <xsl:apply-templates select="innfrielsessaldoforespoersel"/>
                         <xsl:apply-templates select="innfrielsessaldosvar"/>
+                        <xsl:apply-templates select="restgjeldsforespoersel"/>
                     </div>
                 </div>
             </body>
@@ -146,6 +147,9 @@
         </xsl:if>
         <xsl:if test="innfrielsessaldosvar">
             <xsl:text>Svar på innfrielsessaldo</xsl:text>
+        </xsl:if>
+        <xsl:if test="restgjeldsforespoersel">
+            <xsl:text>Forespørsel om restgjeld</xsl:text>
         </xsl:if>
     </xsl:template>
     <xsl:template match="/innfrielsessaldoforespoersel">
@@ -167,6 +171,29 @@
         <xsl:call-template name="ressurser"/>
         <xsl:call-template name="avsender"/>
         <hr/>
+    </xsl:template>
+    <xsl:template match="/restgjeldsforespoersel">
+        <xsl:call-template name="mottaker"/>
+        <xsl:call-template name="eiendom">
+            <xsl:with-param name="registerenhetsliste" select="registerenheterMedHjemmelshavere/registerenhetMedHjemmelshavere"/>
+        </xsl:call-template>
+        <xsl:apply-templates select="prisantydning"/>
+        <xsl:call-template name="ressurser"/>
+        <xsl:call-template name="avsender"/>
+        <hr/>
+    </xsl:template>
+    <xsl:template match="prisantydning">
+        <div class="hovedseksjon">
+            <xsl:call-template name="seksjon">
+                <xsl:with-param name="tittel" select="'Prisantydning'"/>
+            </xsl:call-template>
+            <div class="innhold">
+                <xsl:call-template name="formatNumber">
+                    <xsl:with-param name="prefix" select="'NOK '"/>
+                    <xsl:with-param name="numericValue" select="."/>
+                </xsl:call-template>
+            </div>
+        </div>
     </xsl:template>
     <xsl:template name="formatAccountNumber">
         <xsl:param name="numericValue" select="."/>

--- a/spesifikasjoner/afpant/afpant-model/xslt/restgjeld.xslt
+++ b/spesifikasjoner/afpant/afpant-model/xslt/restgjeld.xslt
@@ -2,13 +2,12 @@
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
     <xsl:output method="html" encoding="utf-8" indent="yes" omit-xml-declaration="yes"/>
     <xsl:decimal-format name="nb-no-space" decimal-separator="," grouping-separator=" " NaN=" "/>
-    
     <!-- Root template -->
     <xsl:template match="/">
         <html>
             <head>
                 <title>
-                    <xsl:call-template name="get-title"/>
+                    <xsl:call-template name="overskrift"/>
                 </title>
                 <style type="text/css">
                     .rolleoverskrift,
@@ -115,9 +114,13 @@
                 <div id="container">
                     <div id="header">
                         <h1 class="overskrift">
-                            <xsl:call-template name="get-title"/>
+                            <xsl:call-template name="overskrift"/>
                         </h1>
                         <hr/>
+                        <xsl:call-template name="footerForH1">
+                            <xsl:with-param name="home" select="*"/>
+                            <xsl:with-param name="meldingsnavn" select="$dsveMeldingstypeBeskrivelse"/>
+                        </xsl:call-template>
                     </div>
                     <div id="body">
                         <xsl:apply-templates select="innfrielsessaldoforespoersel"/>
@@ -127,223 +130,51 @@
             </body>
         </html>
     </xsl:template>
-
-    <!-- Title helper template -->
-    <xsl:template name="get-title">
-        <xsl:choose>
-            <xsl:when test="innfrielsessaldoforespoersel">Forespørsel om innfrielsessaldo</xsl:when>
-            <xsl:when test="innfrielsessaldosvar">Svar på innfrielsessaldo</xsl:when>
-        </xsl:choose>
+    <xsl:template name="overskrift">
+        <xsl:if test="innfrielsessaldoforespoersel">
+            <xsl:text>Forespørsel om innfrielsessaldo</xsl:text>
+        </xsl:if>
+        <xsl:if test="innfrielsessaldosvar">
+            <xsl:text>Svar på innfrielsessaldo</xsl:text>
+        </xsl:if>
     </xsl:template>
-
     <!-- Innfrielsessaldosvar template -->
-    <xsl:template match="innfrielsessaldosvar">
-        <!-- Avsender section -->
-        <div class="hovedseksjon">
-            <div class="seksjonsoverskrift">Avsender</div>
-            <div class="tabell innhold">
-                <div class="kropp">
-                    <xsl:apply-templates select="avsender"/>
-                </div>
-            </div>
-        </div>
-
-        <!-- Mottaker section -->
-        <div class="hovedseksjon">
-            <div class="seksjonsoverskrift">Mottaker</div>
-            <div class="tabell innhold">
-                <div class="kropp">
-                    <xsl:apply-templates select="mottaker"/>
-                </div>
-            </div>
-        </div>
-
-        <!-- Lån section -->
-        <div class="hovedseksjon">
-            <div class="seksjonsoverskrift">Lån</div>
-            <div class="tabell innhold">
-                <div class="kropp">
-                    <xsl:apply-templates select="laanliste/laan"/>
-                </div>
-            </div>
-        </div>
-
-        <!-- Registerenheter section -->
-        <div class="hovedseksjon">
-            <div class="seksjonsoverskrift">Registerenheter med dokumentreferanser</div>
-            <div class="tabell innhold">
-                <div class="kropp">
-                    <xsl:apply-templates select="registerenheterMedDokumentreferanser/registerenhetMedDokumentreferanse"/>
-                </div>
-            </div>
-        </div>
+    <xsl:template match="/innfrielsessaldosvar">
+        <xsl:call-template name="mottaker"/>
+        <xsl:call-template name="eiendom">
+            <xsl:with-param name="registerenhetsliste" select="registerenheterMedDokumentreferanser/registerenhetMedDokumentreferanse"/>
+        </xsl:call-template>
+        <xsl:call-template name="laanliste"/>
+        <xsl:call-template name="ressurser"/>
+        <xsl:call-template name="avsender"/>
+        <hr/>
     </xsl:template>
-
-    <!-- Innfrielsessaldoforespoersel template -->
-    <xsl:template match="innfrielsessaldoforespoersel">
-        <!-- Avsender section -->
-        <div class="hovedseksjon">
-            <div class="seksjonsoverskrift">Avsender</div>
-            <div class="tabell innhold">
-                <div class="kropp">
-                    <xsl:apply-templates select="avsender"/>
-                </div>
-            </div>
-        </div>
-
-        <!-- Mottaker section -->
-        <div class="hovedseksjon">
-            <div class="seksjonsoverskrift">Mottaker</div>
-            <div class="tabell innhold">
-                <div class="kropp">
-                    <xsl:apply-templates select="mottaker"/>
-                </div>
-            </div>
-        </div>
-
-        <!-- Registerenheter section -->
-        <div class="hovedseksjon">
-            <div class="seksjonsoverskrift">Registerenheter med Hjemmelshavere</div>
-            <div class="tabell innhold">
-                <div class="kropp">
-                    <xsl:apply-templates select="registerenheterMedHjemmelshavere"/>
-                </div>
-            </div>
-        </div>
-
-        <!-- Innfrielsesdatoer section -->
-        <div class="hovedseksjon">
-            <div class="seksjonsoverskrift">Innfrielsesdatoer</div>
-            <div class="tabell innhold">
-                <div class="kropp">
-                    <xsl:apply-templates select="innfrielsesdatoer"/>
-                </div>
-            </div>
-        </div>
-    </xsl:template>
-
-    <!-- Lån template -->
-    <xsl:template match="laan">
-        <div class="rad">
-            <div class="celle">
-                <div>Lånenummer: <xsl:value-of select="laanenummer"/></div>
-                <div>Kontonummer: <xsl:call-template name="formatAccountNumber">
-                    <xsl:with-param name="numericValue" select="kontonummer"/>
-                </xsl:call-template>
-                </div>
-                <xsl:if test="kidnummer">
-                    <div>KID: <xsl:value-of select="kidnummer"/></div>
-                </xsl:if>
-                <xsl:if test="betalingsmelding">
-                    <div>Betalingsmelding: <xsl:value-of select="betalingsmelding"/></div>
-                </xsl:if>
-                
-                <table class="innhold" style="border-collapse: collapse;">
-                    <caption class="rolleoverskrift" style="text-align: left;">Saldoer per dato</caption>
-                    <thead>
-                        <tr class="headerrad">
-                            <th style="text-align: left; padding-right: 10px;">Dato</th>
-                            <th style="text-align: left; ">Beløp</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <xsl:for-each select="saldoerPerDato/saldoPerDato">
-                            <tr>
-                                <td style="padding-right: 10px;">
-                                    <xsl:call-template name="format-date">
-                                        <xsl:with-param name="date" select="dato"/>
-                                    </xsl:call-template>
-                                </td>
-                                <td style="text-align: left; ">
-                                    <xsl:call-template name="formatNumber">
-                                        <xsl:with-param name="prefix" select="'Kr. '"/>
-                                        <xsl:with-param name="numericValue" select="beloep"/>
-                                    </xsl:call-template>
-                                </td>
-                            </tr>
-                        </xsl:for-each>
-                    </tbody>
-                </table>
-
-                <xsl:if test="laantakereHjemmelshaver/navn">
-                    <div class="rolleoverskrift">Låntakere som er hjemmelshavere</div>
-                    <xsl:for-each select="laantakereHjemmelshaver/navn">
-                        <div class="innhold"><xsl:value-of select="."/></div>
-                    </xsl:for-each>
-                </xsl:if>
-            </div>
-        </div>
-    </xsl:template>
-
-    <!-- Registerenhet med dokumentreferanse template -->
-    <xsl:template match="registerenhetMedDokumentreferanse">
-        <div class="rad">
-            <div class="celle">
-                <xsl:choose>
-                    <xsl:when test="matrikkel">
-                        <xsl:call-template name="matrikkel">
-                            <xsl:with-param name="matrikkel" select="matrikkel"/>
-                        </xsl:call-template>    
-                    </xsl:when>
-                    <xsl:when test="borettsandel">
-                        <div>Borettsandel:</div>
-                        <div class="innhold">
-                            Borettslag: <xsl:value-of select="borettsandel/@borettslagnavn"/><br/>
-                            Org.nr: <xsl:value-of select="borettsandel/@organisasjonsnummer"/><br/>
-                            Andelsnr: <xsl:value-of select="borettsandel/@andelsnummer"/>
-                        </div>
-                    </xsl:when>
-                    <xsl:when test="aksjeleilighet">
-                        <div>Aksjeleilighet:</div>
-                        <div class="innhold">
-                            Selskap: <xsl:value-of select="aksjeleilighet/@organisasjonsnavn"/><br/>
-                            Org.nr: <xsl:value-of select="aksjeleilighet/@organisasjonsnummer"/><br/>
-                            Leilighetsnr: <xsl:value-of select="aksjeleilighet/@leilighetsnummer"/>
-                        </div>
-                    </xsl:when>
-                </xsl:choose>
-
-                <xsl:if test="pantedokumentreferanser/pantedokumentreferanse">
-                    <div class="rolleoverskrift">Pantedokumentreferanser</div>
-                    <xsl:for-each select="pantedokumentreferanser/pantedokumentreferanse">
-                        <div class="innhold">
-                            Dokumentnr: <xsl:value-of select="@dokumentnummer"/>/<xsl:value-of select="@dokumentaar"/><br/>
-                            Embete: <xsl:value-of select="@embetenummer"/><br/>
-                            Rettsstiftelse: <xsl:value-of select="@rettsstiftelsesnummer"/><br/>
-                            Registrert: <xsl:call-template name="format-datetime">
-                                <xsl:with-param name="datetime" select="@registreringstidspunkt"/>
-                            </xsl:call-template><br/>
-                            Beløp: <xsl:call-template name="formatNumber">
-                                <xsl:with-param name="prefix" select="'Kr. '"/>
-                                <xsl:with-param name="numericValue" select="@beloep"/>
-                            </xsl:call-template>
-                        </div>
-                    </xsl:for-each>
-                </xsl:if>
-            </div>
-        </div>
-    </xsl:template>
-
     <!-- Helper template for formatting Norwegian account numbers -->
     <xsl:template name="formatAccountNumber">
         <xsl:param name="numericValue" select="."/>
         <xsl:value-of select="concat(substring($numericValue, 1, 4), '.', substring($numericValue, 5, 2), '.', substring($numericValue, 7, 5))"/>
     </xsl:template>
-
     <!-- Helper template for formatting dates -->
     <xsl:template name="format-date">
         <xsl:param name="date"/>
-        <xsl:value-of select="substring($date, 9, 2)"/>.<xsl:value-of select="substring($date, 6, 2)"/>.<xsl:value-of select="substring($date, 1, 4)"/>
+        <xsl:value-of select="substring($date, 9, 2)"/>
+        <xsl:text>.</xsl:text>
+        <xsl:value-of select="substring($date, 6, 2)"/>
+        <xsl:text>.</xsl:text>
+        <xsl:value-of select="substring($date, 1, 4)"/>
     </xsl:template>
-
-    <!-- Helper template for formatting date-times -->
-    <xsl:template name="format-datetime">
-        <xsl:param name="datetime"/>
-        <xsl:value-of select="substring($datetime, 9, 2)"/>.<xsl:value-of select="substring($datetime, 6, 2)"/>.<xsl:value-of select="substring($datetime, 1, 4)"/>
-        <xsl:text> </xsl:text>
-        <xsl:value-of select="substring($datetime, 12, 5)"/>
+    <xsl:template name="tiddato">
+        <xsl:param name="dato"/>
+        <xsl:value-of select="substring($dato, 9, 2)"/>
+        <xsl:text>.</xsl:text>
+        <xsl:value-of select="substring($dato, 6, 2)"/>
+        <xsl:text>.</xsl:text>
+        <xsl:value-of select="substring($dato, 1, 4)"/>
+        <xsl:text>&#x20;&#x20;</xsl:text>
+        <xsl:value-of select="substring($dato, 12, 2)"/>
+        <xsl:text>:</xsl:text>
+        <xsl:value-of select="substring($dato, 15, 2)"/>
     </xsl:template>
-
     <!-- Helper template for formatting numbers -->
     <xsl:template name="formatNumber">
         <xsl:param name="prefix"/>
@@ -353,7 +184,6 @@
         </xsl:if>
         <xsl:value-of select="format-number(number($numericValue), '### ### ### ###', 'nb-no-space')"/>
     </xsl:template>
-
     <!-- Helper template for formatting norwegian phone numbers -->
     <xsl:template name="formatPhoneNumber">
         <xsl:param name="prefix"/>
@@ -370,162 +200,431 @@
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>
-
-    <!-- Avsender template -->
-    <xsl:template match="avsender">
-        <div class="rad">
-            <div class="celle kol1">
-                <xsl:value-of select="foretaksnavn"/>
-                <xsl:if test="@id">
-                    <xsl:text> (</xsl:text>
-                    <xsl:value-of select="@id"/>
-                    <xsl:text>)</xsl:text>
-                </xsl:if>
-            </div>
-        </div>
-        <xsl:if test="adresse">
-            <div class="rad">
-                <div class="celle">
-                    <xsl:value-of select="adresse/gatenavn"/>,
-                    <xsl:value-of select="adresse/postnummer"/>
-                    <xsl:text> </xsl:text>
-                    <xsl:value-of select="adresse/poststed"/>
-                </div>
-            </div>
-        </xsl:if>
-        <xsl:if test="kontaktperson">
-            <div class="rad">
-                <div class="celle">
-                    <div><xsl:value-of select="kontaktperson/navn"/></div>
-                    <xsl:if test="kontaktperson/epost">
-                        <div><a href="mailto:{kontaktperson/epost}"><xsl:value-of select="kontaktperson/epost"/></a></div>
-                    </xsl:if>
-                    <xsl:if test="kontaktperson/telefon">
-                        <div>Tlf: <a href="tel:{kontaktperson/telefon}"><xsl:call-template name="formatPhoneNumber">
-                            <xsl:with-param name="phoneValue" select="kontaktperson/telefon"/>
-                        </xsl:call-template></a></div>
-                    </xsl:if>
-                </div>
-            </div>
+    <xsl:template name="organisasjon">
+        <xsl:param name="organisasjon"/>
+        <xsl:value-of select="$organisasjon/foretaksnavn"/>
+        <xsl:text>&#x20;org.nr.&#x20;</xsl:text>
+        <xsl:call-template name="orgnr">
+            <xsl:with-param name="id" select="$organisasjon/@id"/>
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template name="orgnr">
+        <xsl:param name="id"/>
+        <xsl:if test="$id">
+            <xsl:value-of select="substring( format-number($id, '000000000'),1,3)"/>
+            <xsl:text>&#x20;</xsl:text>
+            <xsl:value-of select="substring( format-number($id, '000000000'), 4,3)"/>
+            <xsl:text>&#x20;</xsl:text>
+            <xsl:value-of select="substring( format-number($id, '000000000'), 7,3)"/>
+            <xsl:text>&#xA0;</xsl:text>
+            <a href="https://w2.brreg.no/enhet/sok/detalj.jsp?orgnr={$id}" target="_blank" style="text-decoration: none;">
+                <xsl:text>&#x29C9;</xsl:text>
+            </a>
         </xsl:if>
     </xsl:template>
-
-    <!-- Mottaker template -->
-    <xsl:template match="mottaker">
-        <div class="rad">
-            <div class="celle kol1">
-                <xsl:value-of select="foretaksnavn"/>
-                <xsl:if test="@id">
-                    <xsl:text> (</xsl:text>
-                    <xsl:value-of select="@id"/>
-                    <xsl:text>)</xsl:text>
-                </xsl:if>
-            </div>
-        </div>
-        <xsl:if test="adresse">
-            <div class="rad">
-                <div class="celle">
-                    <xsl:value-of select="adresse/gatenavn"/>,
-                    <xsl:value-of select="adresse/postnummer"/>
-                    <xsl:text> </xsl:text>
-                    <xsl:value-of select="adresse/poststed"/>
-                </div>
-            </div>
+    <xsl:template name="foedselsnr">
+        <xsl:param name="id"/>
+        <xsl:if test="$id">
+            <xsl:value-of select="substring( format-number($id, '00000000000'),1,6)"/>
+            <xsl:text>&#x20;</xsl:text>
+            <xsl:value-of select="substring( format-number($id, '00000000000'), 7,5)"/>
         </xsl:if>
     </xsl:template>
-
-    <!-- Registerenheter template -->
-    <xsl:template match="registerenheterMedHjemmelshavere">
-        <xsl:for-each select="registerenhetMedHjemmelshavere">
-            <div class="rad">
-                <div class="celle">
-                    <xsl:choose>
-                        <xsl:when test="matrikkel">
-                            <xsl:call-template name="matrikkel">
-                                <xsl:with-param name="matrikkel" select="matrikkel"/>
-                            </xsl:call-template>
-                        </xsl:when>
-                        <xsl:when test="borettsandel">
-                            <div>Borettsandel:</div>
-                            <div class="innhold">
-                                Borettslag: <xsl:value-of select="borettsandel/@borettslagnavn"/><br/>
-                                Org.nr: <xsl:value-of select="borettsandel/@organisasjonsnummer"/><br/>
-                                Andelsnr: <xsl:value-of select="borettsandel/@andelsnummer"/>
-                            </div>
-                        </xsl:when>
-                        <xsl:when test="aksjeleilighet">
-                            <div>Aksjeleilighet:</div>
-                            <div class="innhold">
-                                Selskap: <xsl:value-of select="aksjeleilighet/@organisasjonsnavn"/><br/>
-                                Org.nr: <xsl:value-of select="aksjeleilighet/@organisasjonsnummer"/><br/>
-                                Leilighetsnr: <xsl:value-of select="aksjeleilighet/@leilighetsnummer"/>
-                            </div>
-                        </xsl:when>
-                    </xsl:choose>
-                </div>
+    <xsl:template name="kontaktperson">
+        <xsl:param name="kontakt"/>
+        <xsl:param name="referanse"/>
+        <div>
+            <xsl:value-of select="$kontakt/navn"/>
+        </div>
+        <div>
+            <div>
+                <a href="tel:{$kontakt/telefon}">
+                    <xsl:value-of select="format-number( number($kontakt/telefon), '## ## ## ##', 'nb-no-space')"/>
+                </a>&#x20;(telefon)
             </div>
-            <xsl:if test="hjemmelshavere">
+            <div>
+                <a href="tel:{$kontakt/telefondirekte}">
+                    <xsl:value-of select="format-number( number($kontakt/telefondirekte), '## ## ## ##', 'nb-no-space')"/>
+                </a>
+                <xsl:text>&#x20;(direkte)</xsl:text>
+            </div>
+            <div>
+                <a href="mailto:{$kontakt/epost}?Subject=Angående%20{$dsveMeldingstypeBeskrivelse}%20med%20oppdragsnummer%20{$referanse}">
+                    <xsl:value-of select="$kontakt/epost"/>
+                </a>
+            </div>
+        </div>
+    </xsl:template>
+    <xsl:template name="mottaker">
+        <div class="hovedseksjon">
+            <xsl:call-template name="seksjon">
+                <xsl:with-param name="tittel" select="'Mottaker'"/>
+            </xsl:call-template>
+            <div class="tabell innhold">
                 <div class="rad">
+                    <div class="celle kol1">
+                        <xsl:call-template name="organisasjon">
+                            <xsl:with-param name="organisasjon" select="mottaker"/>
+                        </xsl:call-template>
+                    </div>
                     <div class="celle">
-                        <div class="rolleoverskrift">Hjemmelshavere</div>
-                        <xsl:for-each select="hjemmelshavere/hjemmelshaver">
-                            <div class="innhold">
-                                <xsl:choose>
-                                    <xsl:when test="person">
-                                        <xsl:value-of select="person/fornavn"/>
-                                        <xsl:text> </xsl:text>
-                                        <xsl:value-of select="person/etternavn"/>
-                                        <xsl:text> (</xsl:text>
-                                        <xsl:value-of select="person/@id"/>
-                                        <xsl:text>)</xsl:text>
-                                    </xsl:when>
-                                    <xsl:when test="organisasjon">
-                                        <xsl:value-of select="organisasjon/foretaksnavn"/>
-                                        <xsl:text> (</xsl:text>
-                                        <xsl:value-of select="organisasjon/@id"/>
-                                        <xsl:text>)</xsl:text>
-                                    </xsl:when>
-                                </xsl:choose>
+                        <xsl:if test="mottaker/referanse">Referanse:&#x20;
+                            <xsl:value-of select="mottaker/referanse"/>
+                        </xsl:if>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </xsl:template>
+    <xsl:template name="avsender">
+        <div class="hovedseksjon">
+            <xsl:call-template name="seksjon">
+                <xsl:with-param name="tittel" select="'Avsender'"/>
+            </xsl:call-template>
+            <div class="tabell innhold">
+                <div class="rad">
+                    <div class="celle kol1">
+                        <xsl:if test="avsender/kontaktperson">
+                            <div style="padding-bottom:8px;">
+                                <xsl:call-template name="organisasjon">
+                                    <xsl:with-param name="organisasjon" select="avsender"/>
+                                </xsl:call-template>
                             </div>
+                            <xsl:call-template name="kontaktperson">
+                                <xsl:with-param name="kontakt" select="avsender/kontaktperson"/>
+                                <xsl:with-param name="referanse" select="avsender/referanse"/>
+                            </xsl:call-template>
+                        </xsl:if>
+                        <xsl:if test="not(avsender/kontaktperson)">
+                            <div style="padding-bottom:8px;">
+                                <xsl:call-template name="organisasjon">
+                                    <xsl:with-param name="organisasjon" select="avsender"/>
+                                </xsl:call-template>
+                            </div>
+                        </xsl:if>
+                    </div>
+                    <div class="celle">
+                        <xsl:if test="avsender/returnertil">
+                            <xsl:text>Returneres til:&#x20;</xsl:text>
+                            <div style="padding-bottom:8px;">
+                                <xsl:call-template name="organisasjon">
+                                    <xsl:with-param name="organisasjon" select="avsender/returnertil"/>
+                                </xsl:call-template>
+                            </div>
+                        </xsl:if>
+                        <div>
+                            <div>Referanse:</div>
+                            <xsl:value-of select="avsender/referanse"/>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </xsl:template>
+    <xsl:template name="eiendom">
+        <xsl:param name="registerenhetsliste"/>
+        <div class="hovedseksjon">
+            <xsl:call-template name="seksjon">
+                <xsl:with-param name="tittel" select="'Eiendom'"/>
+            </xsl:call-template>
+            <div class="liste">
+                <xsl:call-template name="registerenhetvisning">
+                    <xsl:with-param name="registerenhetsliste" select="$registerenhetsliste"/>
+                </xsl:call-template>
+            </div>
+        </div>
+    </xsl:template>
+    <xsl:template name="registerenhetvisning">
+        <xsl:param name="registerenhetsliste"/>
+        <xsl:for-each select="$registerenhetsliste">
+            <div class="listeelement">
+                <xsl:call-template name="registerenhet">
+                    <xsl:with-param name="registerenhet" select="."/>
+                </xsl:call-template>
+            </div>
+        </xsl:for-each>
+    </xsl:template>
+    <xsl:template name="registerenhet">
+        <xsl:param name="registerenhet"/>
+        <div class="innhold">
+            <xsl:if test="$registerenhet/matrikkel">
+                <xsl:call-template name="eiendomsnivaatype">
+                    <xsl:with-param name="matrikkel" select="$registerenhet/matrikkel"/>
+                </xsl:call-template>
+                <xsl:if test="$registerenhet/adresse">
+                    <xsl:call-template name="adresse">
+                        <xsl:with-param name="adresse" select="$registerenhet/adresse"/>
+                    </xsl:call-template>
+                </xsl:if>
+                <xsl:call-template name="matrikkel">
+                    <xsl:with-param name="matrikkel" select="$registerenhet/matrikkel"/>
+                </xsl:call-template>
+            </xsl:if>
+            <xsl:if test="$registerenhet/borettsandel">
+                <xsl:text>Borettsandel</xsl:text>
+                <xsl:if test="$registerenhet/adresse">
+                    <xsl:call-template name="adresse">
+                        <xsl:with-param name="adresse" select="$registerenhet/adresse"/>
+                    </xsl:call-template>
+                </xsl:if>
+                <xsl:call-template name="borettsandel">
+                    <xsl:with-param name="borettsandel" select="$registerenhet/borettsandel"/>
+                </xsl:call-template>
+            </xsl:if>
+            <xsl:if test="$registerenhet/aksjeleilighet">
+                <xsl:text>Aksjeleilighet</xsl:text>
+                <xsl:if test="$registerenhet/adresse">
+                    <xsl:call-template name="adresse">
+                        <xsl:with-param name="adresse" select="$registerenhet/adresse"/>
+                    </xsl:call-template>
+                </xsl:if>
+                <xsl:call-template name="aksjeleilighet">
+                    <xsl:with-param name="aksjeleilighet" select="$registerenhet/aksjeleilighet"/>
+                </xsl:call-template>
+            </xsl:if>
+            <xsl:if test="$registerenhet/pantedokumentreferanser">
+                <div class="tabell innhold">
+                    <div class="kropp">
+                        <xsl:for-each select="$registerenhet/pantedokumentreferanser/pantedokumentreferanse">
+                            <xsl:call-template name="pant">
+                                <xsl:with-param name="dokument" select="."/>
+                            </xsl:call-template>
                         </xsl:for-each>
                     </div>
                 </div>
             </xsl:if>
-        </xsl:for-each>
+        </div>
     </xsl:template>
-
-    <!-- Innfrielsesdatoer template -->
-    <xsl:template match="innfrielsesdatoer">
-        <xsl:for-each select="innfrielsesdato">
-            <div class="rad">
-                <div class="celle">
-                    <xsl:value-of select="."/>
-                </div>
-            </div>
-        </xsl:for-each>
+    <xsl:template name="aksjeleilighet">
+        <xsl:param name="aksjeleilighet"/>
+        <div>
+            <xsl:value-of select="$aksjeleilighet/@organisasjonsnavn"/>
+            <xsl:text>,&#x20;org.nr.&#x20;</xsl:text>
+            <xsl:call-template name="orgnr">
+                <xsl:with-param name="id" select="$aksjeleilighet/@organisasjonsnummer"/>
+            </xsl:call-template>
+            <xsl:text>,&#x20;leilighetsnummer:&#x20;</xsl:text>
+            <xsl:value-of select="$aksjeleilighet/@leilighetsnummer"/>
+        </div>
     </xsl:template>
-
+    <xsl:template name="borettsandel">
+        <xsl:param name="borettsandel"/>
+        <div>
+            <xsl:value-of select="$borettsandel/@borettslagnavn"/>
+            <xsl:text>,&#x20;org.nr.&#x20;</xsl:text>
+            <xsl:call-template name="orgnr">
+                <xsl:with-param name="id" select="$borettsandel/@organisasjonsnummer"/>
+            </xsl:call-template>
+            <xsl:text>,&#x20;andelnr.&#x20;</xsl:text>
+            <xsl:value-of select="$borettsandel/@andelsnummer"/>
+        </div>
+    </xsl:template>
     <xsl:template name="matrikkel">
         <xsl:param name="matrikkel"/>
         <div>
-        <xsl:text>Kommune:&#x20;</xsl:text>
-        <xsl:value-of select="$matrikkel/@kommunenavn"/>
-        <xsl:text>&#x20;</xsl:text>
-        <xsl:value-of select="$matrikkel/@kommunenummer"/>
-        <xsl:text>,&#x20;gårdsnr.:&#x20;</xsl:text>
-        <xsl:value-of select="$matrikkel/@gaardsnummer"/>
-        <xsl:text>,&#x20;bruksnr.:&#x20;</xsl:text>
-        <xsl:value-of select="$matrikkel/@bruksnummer"/>
-        <!-- Siden XSD sier at seksjonsnummer / festenummer er optional tester vi også mot tom streng (PH) -->
-        <xsl:if test="not($matrikkel/@seksjonsnummer = '0') and not($matrikkel/@seksjonsnummer = '')">
-            <xsl:text>,&#x20;sekjsonsnr.:&#x20;</xsl:text>
-            <xsl:value-of select="$matrikkel/@seksjonsnummer"/>
-        </xsl:if>
-        <xsl:if test="not($matrikkel/@festenummer = '0') and not($matrikkel/@festenummer = '')">
-            <xsl:text>,&#x20;festenr.:&#x20;</xsl:text>
-            <xsl:value-of select="$matrikkel/@festenummer"/>
-        </xsl:if>
+            <xsl:text>Kommune:&#x20;</xsl:text>
+            <xsl:value-of select="$matrikkel/@kommunenavn"/>
+            <xsl:text>&#x20;</xsl:text>
+            <xsl:value-of select="$matrikkel/@kommunenummer"/>
+            <xsl:text>,&#x20;gårdsnr.:&#x20;</xsl:text>
+            <xsl:value-of select="$matrikkel/@gaardsnummer"/>
+            <xsl:text>,&#x20;bruksnr.:&#x20;</xsl:text>
+            <xsl:value-of select="$matrikkel/@bruksnummer"/>
+            <!-- Siden XSD sier at seksjonsnummer / festenummer er optional tester vi også mot tom streng (PH) -->
+            <xsl:if test="not($matrikkel/@seksjonsnummer = '0') and not($matrikkel/@seksjonsnummer = '')">
+                <xsl:text>,&#x20;sekjsonsnr.:&#x20;</xsl:text>
+                <xsl:value-of select="$matrikkel/@seksjonsnummer"/>
+            </xsl:if>
+            <xsl:if test="not($matrikkel/@festenummer = '0') and not($matrikkel/@festenummer = '')">
+                <xsl:text>,&#x20;festenr.:&#x20;</xsl:text>
+                <xsl:value-of select="$matrikkel/@festenummer"/>
+            </xsl:if>
         </div>
     </xsl:template>
-
+    <xsl:template name="eiendomsnivaatype">
+        <xsl:param name="matrikkel"/>
+        <xsl:if test="$matrikkel/@eiendomsnivaa = 'E'">Grunneiendom</xsl:if>
+        <xsl:if test="$matrikkel/@eiendomsnivaa = 'F'">Festeeiendom</xsl:if>
+        <xsl:if test="contains($matrikkel/@eiendomsnivaa, 'F_')">Fremfeste
+            <xsl:value-of select="$matrikkel/@eiendomsnivaa"/>
+        </xsl:if>
+    </xsl:template>
+    <xsl:template name="adresse">
+        <xsl:param name="adresse"/>
+        <div>
+            <xsl:value-of select="$adresse/gatenavn"/>
+            <xsl:text>,&#x20;</xsl:text>
+            <xsl:value-of select="$adresse/postnummer"/>
+            <xsl:text>&#x20;</xsl:text>
+            <xsl:value-of select="$adresse/poststed"/>
+        </div>
+    </xsl:template>
+    <xsl:template name="pant">
+        <xsl:param name="dokument"/>
+        <div class="rad">
+            <div class="celle kol1">
+                <span>
+                    <xsl:value-of select="$dokument/@dokumentaar"/>
+                    <xsl:text>/</xsl:text>
+                    <xsl:value-of select="$dokument/@dokumentnummer"/>
+                    <xsl:text>-</xsl:text>
+                    <xsl:value-of select="$dokument/@rettsstiftelsesnummer"/>
+                    <xsl:text>/</xsl:text>
+                    <xsl:value-of select="$dokument/@embetenummer"/>
+                </span>
+                <br/>
+                <xsl:call-template name="tiddato">
+                    <xsl:with-param name="dato" select="$dokument/@registreringstidspunkt"/>
+                </xsl:call-template>
+                <xsl:if test="$dokument/@kommunenummer">
+                    <br/>
+                    <xsl:text>Kommune:&#x20;</xsl:text>
+                    <xsl:value-of select="$dokument/@kommunenummer"/>
+                </xsl:if>
+            </div>
+            <div class="celle">
+                <span>
+                    <xsl:text>Pantedokument</xsl:text>
+                </span>
+                <br/>
+                <xsl:text>Beløp: </xsl:text>
+                <xsl:call-template name="formatNumber">
+                    <xsl:with-param name="prefix" select="'NOK '"/>
+                    <xsl:with-param name="numericValue" select="$dokument/@beloep"/>
+                </xsl:call-template>
+                <br/>
+            </div>
+        </div>
+    </xsl:template>
+    <xsl:template name="ressurser">
+        <div class="hovedseksjon">
+            <xsl:call-template name="seksjon">
+                <xsl:with-param name="tittel" select="'Vedlegg'"/>
+            </xsl:call-template>
+            <div class="tabell innhold">
+                <div class="rad" style="font-style: italic;">
+                    <div class="celle kol1">Filnavn</div>
+                    <div class="celle">Beskrivelse</div>
+                </div>
+                <xsl:for-each select="metadata/ressurser/vedlegg">
+                    <xsl:call-template name="vedlegg">
+                        <xsl:with-param name="vedlegg" select="."/>
+                    </xsl:call-template>
+                </xsl:for-each>
+            </div>
+        </div>
+    </xsl:template>
+    <xsl:template name="vedlegg">
+        <xsl:param name="vedlegg"/>
+        <div class="rad">
+            <div class="celle">
+                <xsl:value-of select="$vedlegg/navn"/>
+            </div>
+            <div class="celle">
+                <xsl:value-of select="$vedlegg/beskrivelse"/>
+            </div>
+        </div>
+    </xsl:template>
+    <xsl:template name="seksjon">
+        <xsl:param name="tittel"/>
+        <div class="seksjonsoverskrift">
+            <xsl:value-of select="$tittel"/>
+        </div>
+    </xsl:template>
+    <!-- TODO: kontaktperson-template bruker dsveMeldingstypeBeskrivelse-variabelen i en mailto: href, men den er da ikke urlencodet korrekt der (PH) -->
+    <xsl:variable name="dsveMeldingstypeBeskrivelse">
+        <xsl:call-template name="type"/>
+    </xsl:variable>
+    <xsl:template name="type">
+        <xsl:if test="innfrielsessaldoforespoersel">
+            <xsl:text>Forespørsel om innfrielsessaldo</xsl:text>
+        </xsl:if>
+        <xsl:if test="innfrielsessaldosvar">
+            <xsl:text>Svar på innfrielsessaldo</xsl:text>
+        </xsl:if>
+    </xsl:template>
+    <xsl:template name="laanliste">
+        <div class="hovedseksjon">
+            <xsl:call-template name="seksjon">
+                <xsl:with-param name="tittel" select="'Lån'"/>
+            </xsl:call-template>
+            <div class="tabell innhold">
+                <xsl:for-each select="laanliste/laan">
+                    <div class="rad">
+                        <div class="celle kol1">
+                            <div>Lånenummer:
+                                <xsl:value-of select="laanenummer"/>
+                            </div>
+                            <div>Kontonummer:
+                                <xsl:call-template name="formatAccountNumber">
+                                    <xsl:with-param name="numericValue" select="kontonummer"/>
+                                </xsl:call-template>
+                            </div>
+                            <xsl:if test="kidnummer">
+                                <div>KID:
+                                    <xsl:value-of select="kidnummer"/>
+                                </div>
+                            </xsl:if>
+                            <xsl:if test="betalingsmelding">
+                                <div>Betalingsmelding:
+                                    <xsl:value-of select="betalingsmelding"/>
+                                </div>
+                            </xsl:if>
+                            <xsl:if test="laantakereHjemmelshaver/navn">
+                                <div>Låntakere:
+                                    <xsl:for-each select="laantakereHjemmelshaver/navn">
+                                        <div class="innhold">
+                                            <xsl:value-of select="."/>
+                                        </div>
+                                    </xsl:for-each>
+                                </div>
+                            </xsl:if>
+                        </div>
+                        <div class="celle">
+                            <xsl:for-each select="saldoerPerDato/saldoPerDato">
+                                <div>
+                                    <xsl:text>Saldo per </xsl:text>
+                                    <xsl:call-template name="format-date">
+                                        <xsl:with-param name="date" select="dato"/>
+                                    </xsl:call-template>
+                                    <xsl:text>: </xsl:text>
+                                    <span class="tall">
+                                        <xsl:call-template name="formatNumber">
+                                            <xsl:with-param name="prefix" select="'NOK '"/>
+                                            <xsl:with-param name="numericValue" select="beloep"/>
+                                        </xsl:call-template>
+                                    </span>
+                                </div>
+                            </xsl:for-each>
+                            <xsl:if test="laantakerIkkeHjemmelshaver = 'true'">
+                                <div style="color: red; padding-top: 8px;">
+                                    Merk: Låntaker er ikke hjemmelshaver
+                                </div>
+                            </xsl:if>
+                            <xsl:if test="transporterklaering = 'true'">
+                                <div style="padding-top: 8px;">
+                                    Transporterklæring er påkrevd
+                                </div>
+                            </xsl:if>
+                        </div>
+                    </div>
+                    <xsl:if test="position() != last()">
+                        <hr style="margin: 10px 0;"/>
+                    </xsl:if>
+                </xsl:for-each>
+            </div>
+        </div>
+    </xsl:template>
+    <xsl:template name="footerForH1">
+        <xsl:param name="home"/>
+        <xsl:param name="meldingsnavn"/>
+        <div style="padding-bottom:16px;">
+            <small style="float:right;">DSVE&#xA0;
+                <xsl:value-of select="$meldingsnavn"/>,&#x20;opprettet
+                <xsl:call-template name="tiddato">
+                    <xsl:with-param name="dato" select="$home/metadata/opprettet"/>
+                </xsl:call-template>
+            </small>
+        </div>
+    </xsl:template>
 </xsl:stylesheet>

--- a/spesifikasjoner/afpant/afpant-model/xslt/restgjeld.xslt
+++ b/spesifikasjoner/afpant/afpant-model/xslt/restgjeld.xslt
@@ -802,7 +802,7 @@
                             <div class="celle">
                                 <xsl:if test="laantakerIkkeHjemmelshaver = 'true'">
                                     <div style="color: red; padding-top: 8px;">
-                                    Merk: Låntaker er ikke hjemmelshaver
+                                    Det finnes låntaker(e) som ikke er hjemmelshaver
                                 </div>
                                 </xsl:if>
                             </div>

--- a/spesifikasjoner/afpant/afpant-model/xslt/restgjeld.xslt
+++ b/spesifikasjoner/afpant/afpant-model/xslt/restgjeld.xslt
@@ -242,7 +242,7 @@
                 <xsl:for-each select="saldoerPerDato/saldoPerDato">
                     <div class="innhold">
                         <xsl:call-template name="formatNumber">
-                            <xsl:with-param name="prefix" select="'NOK '"/>
+                            <xsl:with-param name="prefix" select="'Kr. '"/>
                             <xsl:with-param name="numericValue" select="beloep"/>
                         </xsl:call-template>
                         <xsl:text> per </xsl:text>
@@ -310,7 +310,7 @@
                                 <xsl:with-param name="datetime" select="@registreringstidspunkt"/>
                             </xsl:call-template><br/>
                             Beløp: <xsl:call-template name="formatNumber">
-                                <xsl:with-param name="prefix" select="'NOK '"/>
+                                <xsl:with-param name="prefix" select="'Kr. '"/>
                                 <xsl:with-param name="numericValue" select="@beloep"/>
                             </xsl:call-template>
                         </div>

--- a/spesifikasjoner/afpant/afpant-model/xslt/restgjeld.xslt
+++ b/spesifikasjoner/afpant/afpant-model/xslt/restgjeld.xslt
@@ -238,19 +238,32 @@
                     <div>Betalingsmelding: <xsl:value-of select="betalingsmelding"/></div>
                 </xsl:if>
                 
-                <div class="rolleoverskrift">Saldoer per dato</div>
-                <xsl:for-each select="saldoerPerDato/saldoPerDato">
-                    <div class="innhold">
-                        <xsl:call-template name="formatNumber">
-                            <xsl:with-param name="prefix" select="'Kr. '"/>
-                            <xsl:with-param name="numericValue" select="beloep"/>
-                        </xsl:call-template>
-                        <xsl:text> per </xsl:text>
-                        <xsl:call-template name="format-date">
-                            <xsl:with-param name="date" select="dato"/>
-                        </xsl:call-template>
-                    </div>
-                </xsl:for-each>
+                <table class="innhold" style="border-collapse: collapse;">
+                    <caption class="rolleoverskrift" style="text-align: left;">Saldoer per dato</caption>
+                    <thead>
+                        <tr class="headerrad">
+                            <th style="text-align: left; padding-right: 10px;">Dato</th>
+                            <th style="text-align: left; ">Beløp</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <xsl:for-each select="saldoerPerDato/saldoPerDato">
+                            <tr>
+                                <td style="padding-right: 10px;">
+                                    <xsl:call-template name="format-date">
+                                        <xsl:with-param name="date" select="dato"/>
+                                    </xsl:call-template>
+                                </td>
+                                <td style="text-align: left; ">
+                                    <xsl:call-template name="formatNumber">
+                                        <xsl:with-param name="prefix" select="'Kr. '"/>
+                                        <xsl:with-param name="numericValue" select="beloep"/>
+                                    </xsl:call-template>
+                                </td>
+                            </tr>
+                        </xsl:for-each>
+                    </tbody>
+                </table>
 
                 <xsl:if test="laantakereHjemmelshaver/navn">
                     <div class="rolleoverskrift">Låntakere som er hjemmelshavere</div>

--- a/spesifikasjoner/afpant/afpant-model/xslt/restgjeld.xslt
+++ b/spesifikasjoner/afpant/afpant-model/xslt/restgjeld.xslt
@@ -201,6 +201,8 @@
             <xsl:with-param name="registerenhetsliste" select="registerenheterMedDokumentreferanser/registerenhetMedDokumentreferanse"/>
         </xsl:call-template>
         <xsl:call-template name="laan"/>
+        <xsl:apply-templates select="sperretForVidereOpplaan"/>
+        <xsl:apply-templates select="bekreftelsePantrettSlettes"/>
         <xsl:call-template name="ressurser"/>
         <xsl:call-template name="avsender"/>
         <hr/>
@@ -337,6 +339,30 @@
                         </xsl:if>
                     </div>
                 </div>
+            </div>
+        </div>
+    </xsl:template>
+    <xsl:template match="sperretForVidereOpplaan">
+        <div class="hovedseksjon">
+            <xsl:call-template name="seksjon">
+                <xsl:with-param name="tittel" select="'Sperret for videre opplån'"/>
+            </xsl:call-template>
+            <div class="innhold">
+                <xsl:call-template name="yesNo">
+                    <xsl:with-param name="booleanValue" select="."/>
+                </xsl:call-template>
+            </div>
+        </div>
+    </xsl:template>
+    <xsl:template match="bekreftelsePantrettSlettes">
+        <div class="hovedseksjon">
+            <xsl:call-template name="seksjon">
+                <xsl:with-param name="tittel" select="'Bekreftelse pantrett slettes'"/>
+            </xsl:call-template>
+            <div class="innhold">
+                <xsl:call-template name="yesNo">
+                    <xsl:with-param name="booleanValue" select="."/>
+                </xsl:call-template>
             </div>
         </div>
     </xsl:template>

--- a/spesifikasjoner/afpant/afpant-model/xslt/restgjeld.xslt
+++ b/spesifikasjoner/afpant/afpant-model/xslt/restgjeld.xslt
@@ -350,6 +350,23 @@
         <xsl:value-of select="format-number(number($numericValue), '### ### ### ###', 'nb-no-space')"/>
     </xsl:template>
 
+    <!-- Helper template for formatting norwegian phone numbers -->
+    <xsl:template name="formatPhoneNumber">
+        <xsl:param name="prefix"/>
+        <xsl:param name="phoneValue" select="."/>
+        <xsl:choose>
+            <xsl:when test="string-length($phoneValue) = 8">
+                <xsl:value-of select="concat(substring($phoneValue, 1, 2), ' ', substring($phoneValue, 3, 2), ' ', substring($phoneValue, 5, 2), ' ', substring($phoneValue, 7, 2))"/>
+            </xsl:when>
+            <xsl:when test="string-length($phoneValue) = 11 and substring($phoneValue, 1, 1) = '+'">
+                <xsl:value-of select="concat(substring($phoneValue, 1, 3), ' ', substring($phoneValue, 4, 2), ' ', substring($phoneValue, 6, 2), ' ', substring($phoneValue, 8, 2), ' ', substring($phoneValue, 10, 2))"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="$phoneValue"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
     <!-- Avsender template -->
     <xsl:template match="avsender">
         <div class="rad">
@@ -380,7 +397,9 @@
                         <div><a href="mailto:{kontaktperson/epost}"><xsl:value-of select="kontaktperson/epost"/></a></div>
                     </xsl:if>
                     <xsl:if test="kontaktperson/telefon">
-                        <div>Tlf: <a href="tel:{kontaktperson/telefon}"><xsl:value-of select="kontaktperson/telefon"/></a></div>
+                        <div>Tlf: <a href="tel:{kontaktperson/telefon}"><xsl:call-template name="formatPhoneNumber">
+                            <xsl:with-param name="phoneValue" select="kontaktperson/telefon"/>
+                        </xsl:call-template></a></div>
                     </xsl:if>
                 </div>
             </div>

--- a/spesifikasjoner/afpant/afpant-model/xslt/restgjeld.xslt
+++ b/spesifikasjoner/afpant/afpant-model/xslt/restgjeld.xslt
@@ -23,7 +23,9 @@
                     }
 
                     .seksjonsoverskrift {
-                        padding-bottom: 8px
+                        padding-bottom: 8px;
+                        margin: 0;
+                        font-size: 18px;
                     }
 
                     .rolleoverskrift {
@@ -54,7 +56,7 @@
                         min-height: 100%;
                         position: relative;
                         margin: 10px;
-                        font-family: helvetica;
+                        font-family: helvetica, sans-serif;
                         max-width: 210mm
                     }
 
@@ -89,6 +91,14 @@
 
                     .kropp {
                         display: table-row-group
+                    }
+
+                    .h3 {
+                        font-weight: 600;
+                        font-size: 15px;
+                        margin-bottom: 2px;
+                        color: #333;
+                        margin-top: 4px;
                     }
 
                     .kol1 {
@@ -138,7 +148,16 @@
             <xsl:text>Svar på innfrielsessaldo</xsl:text>
         </xsl:if>
     </xsl:template>
-    <!-- Innfrielsessaldosvar template -->
+    <xsl:template match="/innfrielsessaldoforespoersel">
+        <xsl:call-template name="mottaker"/>
+        <xsl:call-template name="eiendom">
+            <xsl:with-param name="registerenhetsliste" select="registerenheterMedHjemmelshavere/registerenhetMedHjemmelshavere"/>
+        </xsl:call-template>
+        <xsl:call-template name="innfrielsesdatoer"/>
+        <xsl:call-template name="ressurser"/>
+        <xsl:call-template name="avsender"/>
+        <hr/>
+    </xsl:template>
     <xsl:template match="/innfrielsessaldosvar">
         <xsl:call-template name="mottaker"/>
         <xsl:call-template name="eiendom">
@@ -149,19 +168,17 @@
         <xsl:call-template name="avsender"/>
         <hr/>
     </xsl:template>
-    <!-- Helper template for formatting Norwegian account numbers -->
     <xsl:template name="formatAccountNumber">
         <xsl:param name="numericValue" select="."/>
         <xsl:value-of select="concat(substring($numericValue, 1, 4), '.', substring($numericValue, 5, 2), '.', substring($numericValue, 7, 5))"/>
     </xsl:template>
-    <!-- Helper template for formatting dates -->
-    <xsl:template name="format-date">
-        <xsl:param name="date"/>
-        <xsl:value-of select="substring($date, 9, 2)"/>
+    <xsl:template name="dato">
+        <xsl:param name="dato"/>
+        <xsl:value-of select="substring($dato, 9, 2)"/>
         <xsl:text>.</xsl:text>
-        <xsl:value-of select="substring($date, 6, 2)"/>
+        <xsl:value-of select="substring($dato, 6, 2)"/>
         <xsl:text>.</xsl:text>
-        <xsl:value-of select="substring($date, 1, 4)"/>
+        <xsl:value-of select="substring($dato, 1, 4)"/>
     </xsl:template>
     <xsl:template name="tiddato">
         <xsl:param name="dato"/>
@@ -175,7 +192,6 @@
         <xsl:text>:</xsl:text>
         <xsl:value-of select="substring($dato, 15, 2)"/>
     </xsl:template>
-    <!-- Helper template for formatting numbers -->
     <xsl:template name="formatNumber">
         <xsl:param name="prefix"/>
         <xsl:param name="numericValue"/>
@@ -184,7 +200,6 @@
         </xsl:if>
         <xsl:value-of select="format-number(number($numericValue), '### ### ### ###', 'nb-no-space')"/>
     </xsl:template>
-    <!-- Helper template for formatting norwegian phone numbers -->
     <xsl:template name="formatPhoneNumber">
         <xsl:param name="prefix"/>
         <xsl:param name="phoneValue" select="."/>
@@ -211,11 +226,11 @@
     <xsl:template name="orgnr">
         <xsl:param name="id"/>
         <xsl:if test="$id">
-            <xsl:value-of select="substring( format-number($id, '000000000'),1,3)"/>
+            <xsl:value-of select="substring(format-number($id, '000000000'), 1,3)"/>
             <xsl:text>&#x20;</xsl:text>
-            <xsl:value-of select="substring( format-number($id, '000000000'), 4,3)"/>
+            <xsl:value-of select="substring(format-number($id, '000000000'), 4,3)"/>
             <xsl:text>&#x20;</xsl:text>
-            <xsl:value-of select="substring( format-number($id, '000000000'), 7,3)"/>
+            <xsl:value-of select="substring(format-number($id, '000000000'), 7,3)"/>
             <xsl:text>&#xA0;</xsl:text>
             <a href="https://w2.brreg.no/enhet/sok/detalj.jsp?orgnr={$id}" target="_blank" style="text-decoration: none;">
                 <xsl:text>&#x29C9;</xsl:text>
@@ -225,9 +240,9 @@
     <xsl:template name="foedselsnr">
         <xsl:param name="id"/>
         <xsl:if test="$id">
-            <xsl:value-of select="substring( format-number($id, '00000000000'),1,6)"/>
+            <xsl:value-of select="substring(format-number($id, '00000000000'), 1,6)"/>
             <xsl:text>&#x20;</xsl:text>
-            <xsl:value-of select="substring( format-number($id, '00000000000'), 7,5)"/>
+            <xsl:value-of select="substring(format-number($id, '00000000000'), 7,5)"/>
         </xsl:if>
     </xsl:template>
     <xsl:template name="kontaktperson">
@@ -239,12 +254,12 @@
         <div>
             <div>
                 <a href="tel:{$kontakt/telefon}">
-                    <xsl:value-of select="format-number( number($kontakt/telefon), '## ## ## ##', 'nb-no-space')"/>
+                    <xsl:value-of select="format-number(number($kontakt/telefon), '## ## ## ##', 'nb-no-space')"/>
                 </a>&#x20;(telefon)
             </div>
             <div>
                 <a href="tel:{$kontakt/telefondirekte}">
-                    <xsl:value-of select="format-number( number($kontakt/telefondirekte), '## ## ## ##', 'nb-no-space')"/>
+                    <xsl:value-of select="format-number(number($kontakt/telefondirekte), '## ## ## ##', 'nb-no-space')"/>
                 </a>
                 <xsl:text>&#x20;(direkte)</xsl:text>
             </div>
@@ -348,9 +363,11 @@
         <xsl:param name="registerenhet"/>
         <div class="innhold">
             <xsl:if test="$registerenhet/matrikkel">
-                <xsl:call-template name="eiendomsnivaatype">
-                    <xsl:with-param name="matrikkel" select="$registerenhet/matrikkel"/>
-                </xsl:call-template>
+                <h3 class="h3">
+                    <xsl:call-template name="eiendomsnivaatype">
+                        <xsl:with-param name="matrikkel" select="$registerenhet/matrikkel"/>
+                    </xsl:call-template>
+                </h3>
                 <xsl:if test="$registerenhet/adresse">
                     <xsl:call-template name="adresse">
                         <xsl:with-param name="adresse" select="$registerenhet/adresse"/>
@@ -361,7 +378,7 @@
                 </xsl:call-template>
             </xsl:if>
             <xsl:if test="$registerenhet/borettsandel">
-                <xsl:text>Borettsandel</xsl:text>
+                <h3 class="h3">Borettsandel</h3>
                 <xsl:if test="$registerenhet/adresse">
                     <xsl:call-template name="adresse">
                         <xsl:with-param name="adresse" select="$registerenhet/adresse"/>
@@ -372,7 +389,7 @@
                 </xsl:call-template>
             </xsl:if>
             <xsl:if test="$registerenhet/aksjeleilighet">
-                <xsl:text>Aksjeleilighet</xsl:text>
+                <h3 class="h3">Aksjeleilighet</h3>
                 <xsl:if test="$registerenhet/adresse">
                     <xsl:call-template name="adresse">
                         <xsl:with-param name="adresse" select="$registerenhet/adresse"/>
@@ -388,6 +405,21 @@
                         <xsl:for-each select="$registerenhet/pantedokumentreferanser/pantedokumentreferanse">
                             <xsl:call-template name="pant">
                                 <xsl:with-param name="dokument" select="."/>
+                            </xsl:call-template>
+                        </xsl:for-each>
+                    </div>
+                </div>
+            </xsl:if>
+            <xsl:if test="$registerenhet/hjemmelshavere">
+                <div class="tabell innhold">
+                    <div class="kropp">
+                        <h4 class="h3">
+                            <xsl:text>Hjemmelshaver</xsl:text>
+                            <xsl:if test="count($registerenhet/hjemmelshavere/hjemmelshaver) &gt; 1">e</xsl:if>
+                        </h4>
+                        <xsl:for-each select="$registerenhet/hjemmelshavere/hjemmelshaver">
+                            <xsl:call-template name="person_oneliner">
+                                <xsl:with-param name="rettssubjekt" select="."/>
                             </xsl:call-template>
                         </xsl:for-each>
                     </div>
@@ -459,6 +491,60 @@
             <xsl:value-of select="$adresse/poststed"/>
         </div>
     </xsl:template>
+    <xsl:template name="hjemmelshaver">
+        <xsl:param name="hjemmelshaver"/>
+        <xsl:if test="$hjemmelshaver/organisasjon">
+            <div style="padding-bottom:8px;">
+                <xsl:call-template name="organisasjon">
+                    <xsl:with-param name="organisasjon" select="$hjemmelshaver/organisasjon"/>
+                </xsl:call-template>
+            </div>
+        </xsl:if>
+        <div>
+            <xsl:value-of select="$hjemmelshaver/navn"/>
+        </div>
+    </xsl:template>
+    <xsl:template name="person_oneliner">
+        <xsl:param name="rettssubjekt"/>
+        <div>
+            <xsl:if test="$rettssubjekt/person">
+                <xsl:value-of select="$rettssubjekt/person/fornavn"/>
+                <xsl:text>&#x20;</xsl:text>
+                <xsl:value-of select="$rettssubjekt/person/etternavn"/>,
+                <xsl:text>fnr. </xsl:text>
+                <xsl:call-template name="foedselsnr">
+                    <xsl:with-param name="id" select="$rettssubjekt/person/@id"/>
+                </xsl:call-template>
+            </xsl:if>
+            <xsl:if test="$rettssubjekt/organisasjon">
+                <xsl:value-of select="$rettssubjekt/organisasjon/foretaksnavn"/>,
+                <xsl:text>org.nr. </xsl:text>
+                <xsl:call-template name="orgnr">
+                    <xsl:with-param name="id" select="$rettssubjekt/organisasjon/@id"/>
+                </xsl:call-template>
+            </xsl:if>
+        </div>
+    </xsl:template>
+    <xsl:template name="innfrielsesdatoer">
+        <div class="hovedseksjon">
+            <xsl:call-template name="seksjon">
+                <xsl:with-param name="tittel" select="'Innfrielsesdatoer'"/>
+            </xsl:call-template>
+            <div class="tabell innhold">
+                <div class="rad">
+                    <div class="celle kol1">
+                        <xsl:for-each select="innfrielsesdatoer/innfrielsesdato">
+                            <div>
+                                <xsl:call-template name="dato">
+                                    <xsl:with-param name="dato" select="."/>
+                                </xsl:call-template>
+                            </div>
+                        </xsl:for-each>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </xsl:template>
     <xsl:template name="pant">
         <xsl:param name="dokument"/>
         <div class="rad">
@@ -527,9 +613,9 @@
     </xsl:template>
     <xsl:template name="seksjon">
         <xsl:param name="tittel"/>
-        <div class="seksjonsoverskrift">
+        <h2 class="seksjonsoverskrift">
             <xsl:value-of select="$tittel"/>
-        </div>
+        </h2>
     </xsl:template>
     <!-- TODO: kontaktperson-template bruker dsveMeldingstypeBeskrivelse-variabelen i en mailto: href, men den er da ikke urlencodet korrekt der (PH) -->
     <xsl:variable name="dsveMeldingstypeBeskrivelse">
@@ -584,8 +670,8 @@
                             <xsl:for-each select="saldoerPerDato/saldoPerDato">
                                 <div>
                                     <xsl:text>Saldo per </xsl:text>
-                                    <xsl:call-template name="format-date">
-                                        <xsl:with-param name="date" select="dato"/>
+                                    <xsl:call-template name="dato">
+                                        <xsl:with-param name="dato" select="dato"/>
                                     </xsl:call-template>
                                     <xsl:text>: </xsl:text>
                                     <span class="tall">

--- a/spesifikasjoner/afpant/afpant-model/xslt/restgjeld.xslt
+++ b/spesifikasjoner/afpant/afpant-model/xslt/restgjeld.xslt
@@ -227,7 +227,10 @@
         <div class="rad">
             <div class="celle">
                 <div>Lånenummer: <xsl:value-of select="laanenummer"/></div>
-                <div>Kontonummer: <xsl:value-of select="kontonummer"/></div>
+                <div>Kontonummer: <xsl:call-template name="formatAccountNumber">
+                    <xsl:with-param name="numericValue" select="kontonummer"/>
+                </xsl:call-template>
+                </div>
                 <xsl:if test="kidnummer">
                     <div>KID: <xsl:value-of select="kidnummer"/></div>
                 </xsl:if>
@@ -315,6 +318,12 @@
                 </xsl:if>
             </div>
         </div>
+    </xsl:template>
+
+    <!-- Helper template for formatting Norwegian account numbers -->
+    <xsl:template name="formatAccountNumber">
+        <xsl:param name="numericValue" select="."/>
+        <xsl:value-of select="concat(substring($numericValue, 1, 4), '.', substring($numericValue, 5, 2), '.', substring($numericValue, 7, 5))"/>
     </xsl:template>
 
     <!-- Helper template for formatting dates -->

--- a/spesifikasjoner/afpant/afpant-model/xslt/restgjeld.xslt
+++ b/spesifikasjoner/afpant/afpant-model/xslt/restgjeld.xslt
@@ -136,6 +136,7 @@
                         <xsl:apply-templates select="innfrielsessaldoforespoersel"/>
                         <xsl:apply-templates select="innfrielsessaldosvar"/>
                         <xsl:apply-templates select="restgjeldsforespoersel"/>
+                        <xsl:apply-templates select="restgjeldssvar"/>
                     </div>
                 </div>
             </body>
@@ -150,6 +151,9 @@
         </xsl:if>
         <xsl:if test="restgjeldsforespoersel">
             <xsl:text>Forespørsel om restgjeld</xsl:text>
+        </xsl:if>
+        <xsl:if test="restgjeldssvar">
+            <xsl:text>Svar på restgjeld</xsl:text>
         </xsl:if>
     </xsl:template>
     <xsl:template match="/innfrielsessaldoforespoersel">
@@ -178,6 +182,16 @@
             <xsl:with-param name="registerenhetsliste" select="registerenheterMedHjemmelshavere/registerenhetMedHjemmelshavere"/>
         </xsl:call-template>
         <xsl:apply-templates select="prisantydning"/>
+        <xsl:call-template name="ressurser"/>
+        <xsl:call-template name="avsender"/>
+        <hr/>
+    </xsl:template>
+    <xsl:template match="/restgjeldssvar">
+        <xsl:call-template name="mottaker"/>
+        <xsl:call-template name="eiendom">
+            <xsl:with-param name="registerenhetsliste" select="registerenheterMedDokumentreferanser/registerenhetMedDokumentreferanse"/>
+        </xsl:call-template>
+        <xsl:call-template name="laanliste"/>
         <xsl:call-template name="ressurser"/>
         <xsl:call-template name="avsender"/>
         <hr/>
@@ -654,6 +668,12 @@
         </xsl:if>
         <xsl:if test="innfrielsessaldosvar">
             <xsl:text>Svar på innfrielsessaldo</xsl:text>
+        </xsl:if>
+        <xsl:if test="restgjeldsforespoersel">
+            <xsl:text>Forespørsel om restgjeld</xsl:text>
+        </xsl:if>
+        <xsl:if test="restgjeldssvar">
+            <xsl:text>Svar på restgjeld</xsl:text>
         </xsl:if>
     </xsl:template>
     <xsl:template name="laanliste">

--- a/spesifikasjoner/afpant/afpant-model/xslt/restgjeld.xslt
+++ b/spesifikasjoner/afpant/afpant-model/xslt/restgjeld.xslt
@@ -118,6 +118,15 @@
                     .tall {
                         text-align: right;
                     }
+
+                    table {
+                        padding: 0;
+                        border-collapse: collapse;
+                    }
+
+                    table td {
+                        padding-right: 10px;
+                    }
                 </style>
             </head>
             <body>
@@ -171,7 +180,7 @@
         <xsl:call-template name="eiendom">
             <xsl:with-param name="registerenhetsliste" select="registerenheterMedDokumentreferanser/registerenhetMedDokumentreferanse"/>
         </xsl:call-template>
-        <xsl:call-template name="laanliste"/>
+        <xsl:call-template name="laan"/>
         <xsl:call-template name="ressurser"/>
         <xsl:call-template name="avsender"/>
         <hr/>
@@ -191,7 +200,7 @@
         <xsl:call-template name="eiendom">
             <xsl:with-param name="registerenhetsliste" select="registerenheterMedDokumentreferanser/registerenhetMedDokumentreferanse"/>
         </xsl:call-template>
-        <xsl:call-template name="laanliste"/>
+        <xsl:call-template name="laan"/>
         <xsl:call-template name="ressurser"/>
         <xsl:call-template name="avsender"/>
         <hr/>
@@ -202,8 +211,7 @@
                 <xsl:with-param name="tittel" select="'Prisantydning'"/>
             </xsl:call-template>
             <div class="innhold">
-                <xsl:call-template name="formatNumber">
-                    <xsl:with-param name="prefix" select="'NOK '"/>
+                <xsl:call-template name="formatCurrency">
                     <xsl:with-param name="numericValue" select="."/>
                 </xsl:call-template>
             </div>
@@ -615,8 +623,7 @@
                 </span>
                 <br/>
                 <xsl:text>Beløp: </xsl:text>
-                <xsl:call-template name="formatNumber">
-                    <xsl:with-param name="prefix" select="'NOK '"/>
+                <xsl:call-template name="formatCurrency">
                     <xsl:with-param name="numericValue" select="$dokument/@beloep"/>
                 </xsl:call-template>
                 <br/>
@@ -676,7 +683,7 @@
             <xsl:text>Svar på restgjeld</xsl:text>
         </xsl:if>
     </xsl:template>
-    <xsl:template name="laanliste">
+    <xsl:template name="laan">
         <div class="hovedseksjon">
             <xsl:call-template name="seksjon">
                 <xsl:with-param name="tittel" select="'Lån'"/>
@@ -685,23 +692,103 @@
                 <xsl:for-each select="laanliste/laan">
                     <div class="rad">
                         <div class="celle kol1">
-                            <div>Lånenummer:
-                                <xsl:value-of select="laanenummer"/>
-                            </div>
-                            <div>Kontonummer:
-                                <xsl:call-template name="formatAccountNumber">
-                                    <xsl:with-param name="numericValue" select="kontonummer"/>
+                            <table>
+                                <xsl:if test="rammelaan">
+                                    <tr>
+                                        <td>Rammelån</td>
+                                        <td>
+                                            <xsl:call-template name="yesNo">
+                                                <xsl:with-param name="booleanValue" select="rammelaan"/>
+                                            </xsl:call-template>
+                                        </td>
+                                        <td>
+                                            <xsl:if test="rammelaan = 'true'">
+                                                <xsl:if test="oevreGrenseRammelaan">Øvre grense:
+                                                    <xsl:call-template name="formatCurrency">
+                                                        <xsl:with-param name="numericValue" select="oevreGrenseRammelaan"/>
+                                                    </xsl:call-template>
+                                                </xsl:if>
+                                            </xsl:if>
+                                        </td>
+                                    </tr>
+                                </xsl:if>
+                                <xsl:if test="fastrente">
+                                    <tr>
+                                        <td>Fast rente</td>
+                                        <td>
+                                            <xsl:call-template name="yesNo">
+                                                <xsl:with-param name="booleanValue" select="fastrente"/>
+                                            </xsl:call-template>
+                                        </td>
+                                    </tr>
+                                </xsl:if>
+                                <xsl:if test="realkausjon">
+                                    <tr>
+                                        <td>Realkausjon</td>
+                                        <td>
+                                            <xsl:call-template name="yesNo">
+                                                <xsl:with-param name="booleanValue" select="realkausjon"/>
+                                            </xsl:call-template>
+                                        </td>
+                                    </tr>
+                                </xsl:if>
+                                <tr>
+                                    <td>Mellomfinansiering</td>
+                                    <td>
+                                        <xsl:call-template name="yesNo">
+                                            <xsl:with-param name="booleanValue" select="transporterklaering"/>
+                                        </xsl:call-template>
+                                    </td>
+                                    <xsl:if test="transporterklaering = 'true'">
+                                        <td>Transporterklæring</td>
+                                    </xsl:if>
+                                </tr>
+                                <tr>
+                                    <td>Lånenummer</td>
+                                    <td>
+                                        <xsl:value-of select="laanenummer"/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>Kontonummer</td>
+                                    <td>
+                                        <xsl:call-template name="formatAccountNumber">
+                                            <xsl:with-param name="numericValue" select="kontonummer"/>
+                                        </xsl:call-template>
+                                    </td>
+                                </tr>
+                                <xsl:if test="kidnummer">
+                                    <tr>
+                                        <td>KID</td>
+                                        <td>
+                                            <xsl:value-of select="kidnummer"/>
+                                        </td>
+                                    </tr>
+                                </xsl:if>
+                                <xsl:if test="betalingsmelding">
+                                    <tr>
+                                        <td>Betalingsmelding</td>
+                                        <td>
+                                            <xsl:value-of select="betalingsmelding"/>
+                                        </td>
+                                    </tr>
+                                </xsl:if>
+                                <xsl:if test="saldo">
+                                    <tr>
+                                        <td>Restgjeld</td>
+                                        <td>
+                                            <xsl:call-template name="formatCurrency">
+                                                <xsl:with-param name="numericValue" select="saldo"/>
+                                            </xsl:call-template>
+                                        </td>
+                                        <td>På tidspunktet for besvarelse</td>
+                                    </tr>
+                                </xsl:if>
+                            </table>
+                            <xsl:if test="saldoerPerDato">
+                                <xsl:call-template name="saldoerPerDatoListe">
+                                    <xsl:with-param name="saldoerPerDato" select="saldoerPerDato"/>
                                 </xsl:call-template>
-                            </div>
-                            <xsl:if test="kidnummer">
-                                <div>KID:
-                                    <xsl:value-of select="kidnummer"/>
-                                </div>
-                            </xsl:if>
-                            <xsl:if test="betalingsmelding">
-                                <div>Betalingsmelding:
-                                    <xsl:value-of select="betalingsmelding"/>
-                                </div>
                             </xsl:if>
                             <xsl:if test="laantakereHjemmelshaver/navn">
                                 <div>Låntakere:
@@ -712,33 +799,13 @@
                                     </xsl:for-each>
                                 </div>
                             </xsl:if>
-                        </div>
-                        <div class="celle">
-                            <xsl:for-each select="saldoerPerDato/saldoPerDato">
-                                <div>
-                                    <xsl:text>Saldo per </xsl:text>
-                                    <xsl:call-template name="dato">
-                                        <xsl:with-param name="dato" select="dato"/>
-                                    </xsl:call-template>
-                                    <xsl:text>: </xsl:text>
-                                    <span class="tall">
-                                        <xsl:call-template name="formatNumber">
-                                            <xsl:with-param name="prefix" select="'NOK '"/>
-                                            <xsl:with-param name="numericValue" select="beloep"/>
-                                        </xsl:call-template>
-                                    </span>
-                                </div>
-                            </xsl:for-each>
-                            <xsl:if test="laantakerIkkeHjemmelshaver = 'true'">
-                                <div style="color: red; padding-top: 8px;">
+                            <div class="celle">
+                                <xsl:if test="laantakerIkkeHjemmelshaver = 'true'">
+                                    <div style="color: red; padding-top: 8px;">
                                     Merk: Låntaker er ikke hjemmelshaver
                                 </div>
-                            </xsl:if>
-                            <xsl:if test="transporterklaering = 'true'">
-                                <div style="padding-top: 8px;">
-                                    Transporterklæring er påkrevd
-                                </div>
-                            </xsl:if>
+                                </xsl:if>
+                            </div>
                         </div>
                     </div>
                     <xsl:if test="position() != last()">
@@ -747,6 +814,44 @@
                 </xsl:for-each>
             </div>
         </div>
+    </xsl:template>
+    <xsl:template name="saldoerPerDatoListe">
+        <xsl:param name="saldoerPerDato"/>
+        <xsl:for-each select="saldoerPerDato/saldoPerDato">
+            <div>
+                <xsl:text>Saldo per </xsl:text>
+                <xsl:call-template name="dato">
+                    <xsl:with-param name="dato" select="dato"/>
+                </xsl:call-template>
+                <xsl:text>: </xsl:text>
+                <span class="tall">
+                    <xsl:call-template name="formatCurrency">
+                        <xsl:with-param name="numericValue" select="beloep"/>
+                    </xsl:call-template>
+                </span>
+            </div>
+        </xsl:for-each>
+    </xsl:template>
+    <xsl:template name="formatCurrency">
+        <xsl:param name="numericValue"/>
+        <xsl:call-template name="formatNumber">
+            <xsl:with-param name="prefix" select="'NOK '"/>
+            <xsl:with-param name="numericValue" select="$numericValue"/>
+        </xsl:call-template>
+    </xsl:template>
+    <xsl:template name="yesNo">
+        <xsl:param name="booleanValue"/>
+        <xsl:choose>
+            <xsl:when test="$booleanValue= 'true'">
+                <xsl:value-of select="'Ja'"/>
+            </xsl:when>
+            <xsl:when test="$booleanValue= 'false'">
+                <xsl:value-of select="'Nei'"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:text>Ukjent</xsl:text>
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:template>
     <xsl:template name="footerForH1">
         <xsl:param name="home"/>


### PR DESCRIPTION
Ref #72

Edit: Kan testes med en enkel webserver, feks `npx http-server -o spesifikasjoner/afpant/afpant-model/examples` (så gå til feks http://127.0.0.1:8080/spesifikasjoner/afpant/afpant-model/examples/restgjeldssvar_1.0.xml)

Bare for spesifikasjoner/afpant/afpant-model/examples/innfrielsessaldoforespoersel_1.0.xml og spesifikasjoner/afpant/afpant-model/examples/innfrielsessaldosvar_1.0.xml til å begynne med, for å se at jeg er på riktig spor. Se spesifikasjoner/afpant/afpant-model/afpant-model.md for hvordan dette kan testes. 

Edit: Her er oppdaterte screenshots etter siste versjon ([018bb50](https://github.com/bitsnorge/e-tinglysing-afpant/pull/73/commits/018bb503e59ac1d0d78cde4208d93608815767e6)):

![127 0 0 1_8080_spesifikasjoner_afpant_afpant-model_examples_restgjeldssvar_1 0 xml](https://github.com/user-attachments/assets/4074d806-af72-4deb-a717-9be3a52cc73f)
![127 0 0 1_8080_spesifikasjoner_afpant_afpant-model_examples_restgjeldsforespoersel_1 0 xml](https://github.com/user-attachments/assets/a7b786ce-ae8a-45f3-bc3e-b4d7188a8211)
![127 0 0 1_8080_spesifikasjoner_afpant_afpant-model_examples_innfrielsessaldosvar_1 0 xml](https://github.com/user-attachments/assets/0dd019e6-a51d-41b7-a858-0d9bf80c8752)
![127 0 0 1_8080_spesifikasjoner_afpant_afpant-model_examples_innfrielsessaldoforespoersel_1 0 xml](https://github.com/user-attachments/assets/b158b73b-d0c0-4017-8174-4a19eba2ee06)


Ikke noe fancy, bare brukt samme stil som dsve.xslt. 