### PR TITLE
doc: GitHub Actions workflows er klare til gjennomgang

### DIFF
--- a/.github/workflows/release-and-publish.yaml
+++ b/.github/workflows/release-and-publish.yaml
@@ -1,0 +1,106 @@
+name: release-and-publish
+
+on:
+  # Triggers the workflow on push to master i.e when somone merges a pull request on master
+  push:
+    branches: [ "master" ]
+jobs:
+  # This workflow has two jobs, 1 creates a new release, the second pushes the release to the CDN
+  release:
+    name: Release new version
+    # Outputs the value of the check if doc release, the next job will not run if this fails
+    outputs:
+      releaseType: ${{ steps.release.outputs.releaseType}}
+      newVersionNumber: ${{ steps.newVersionNumber.outputs.newVersionNumber}}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Checks what kind of release this is based on the commit message, doc changes does not trigger a new release
+      # We can assume that the commit message follows the naming conventions here because they have been sanitized during the PR
+      - name: Check release type
+        id: release
+        run: .github/workflows/scripts/shared/determineReleaseType.ps1
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          repoPath: ${{ github.repository }}
+          gitHubHost: ${{ github.server_url }}
+          mergeCommitMessage: ${{ github.event.head_commit.message }}
+
+      #Does not run if the merge was a doc change
+      - name: Determine new version number
+        id: newVersionNumber
+        if: steps.release.outputs.releaseType != 'doc'
+        run: .github/workflows/scripts/release-and-publish/findNewVersion.ps1
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RepositoryURI: ${{ github.repository }}
+          RepositoryHost: ${{ github.server_url }}
+          ReleaseType: ${{ steps.release.outputs.releaseType }}
+
+      #Does not run if the merge was a doc change
+      #Must have a tag before creating a release
+      - name: Create new tag
+        if: steps.release.outputs.releaseType != 'doc'
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git tag -a "${{ steps.newVersionNumber.outputs.newVersionNumber}}" -m "Release v${{ steps.newVersionNumber.outputs.newVersionNumber}}"
+          git push origin
+
+      #Does not run if the merge was a doc change
+      - name: Create release
+        if: steps.release.outputs.releaseType != 'doc'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create ${{ steps.newVersionNumber.outputs.newVersionNumber}} \
+          --repo ${{ github.repositoryUrl }} \
+          --title 'v${{ steps.newVersionNumber.outputs.newVersionNumber}}' \
+          --generate-notes \
+          --notes "# New release version: ${{ steps.newVersionNumber.outputs.newVersionNumber}} *This is an automated release triggered by the merge of a pull request in the repository: ${{ github.repositoryUrl }}. Please see the Pull request that caused this release for further details.*"
+
+  cdn-push:
+    name: Push new release to Azure CDN
+    # Does not run if the release is a doc release
+    needs: [release]
+    if: needs.release.outputs.releaseType != 'doc'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Azure login
+        uses: azure/login@v2
+        with:
+          creds: '{ "clientSecret": "${{ secrets.AZURE_CDN_SERVICE_PRINCIPAL_SECRET }}", "subscriptionId": "${{ secrets.AZURE_CDN_SUBSCRIPTION_ID }}", "tenantId": "${{ secrets.AZURE_CDN_TENANT_ID }}", "clientId": "${{ secrets.AZURE_CDN_SERVICE_PRINCIPAL_CLIENTID }}"}'
+
+      - name: Set up Azure CLI
+        run: |
+          curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+
+      - name: Prepare files for upload
+        run: .github/workflows/scripts/release-and-publish/uploadAfpantFilesToAzure.ps1
+        shell: pwsh
+
+      - name: Upload release to CDN
+        shell: pwsh
+        env:
+          azureStorageBlobContainerName: ${{ secrets.AZURE_STORAGE_BLOB_CONTAINER_NAME }}
+          azureStorageAccountName: ${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}
+          newVersionNumber: ${{ needs.release.outputs.newVersionNumber }}
+        run: |
+          az storage blob upload-batch --auth-mode login -d $Env:azureStorageBlobContainerName --account-name $Env:azureStorageAccountName --destination-path "dsve/v/$Env:newVersionNumber/" --source "./actions-tmp/"
+
+      - name: Purge CDN cache
+        shell: pwsh
+        env:
+          azureCDNProfileName: ${{secrets.AZURE_CDN_PROFILE_NAME}}
+          azureCDNEndpointName: ${{secrets.AZURE_CDN_ENDPOINT_NAME}}
+          azureCDNResourceGroup: ${{secrets.AZURE_CDN_PROFILE_RESOURCE_GROUP}}
+        run: |
+          az cdn endpoint purge --content-paths "/dsve/*" --profile-name $Env:azureCDNProfileName --name $Env:azureCDNEndpointName --resource-group $Env:azureCDNResourceGroup

--- a/.github/workflows/sanitize-commit.yaml
+++ b/.github/workflows/sanitize-commit.yaml
@@ -1,0 +1,37 @@
+name: sanatize-commnit
+on:
+  pull_request:
+    types: [opened, reopened, edited, synchronize]
+jobs:
+  check-commit:
+    name: Check commit message
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Checks what kind of release this is based on the commit message, doc changes does not trigger a new release
+        # Uses the same script as the same step in the release-and-publish workflow. This script errors out if the naming convention is not followed.
+      - name: Check release type
+        id: releaseType
+        run: .github/workflows/scripts/shared/determineReleaseType.ps1
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          repoPath: ${{ github.repository }}
+          gitHubHost: ${{ github.server_url }}
+          prPath: ${{ github.ref }}
+
+
+      - name: Approve the Pull Request
+        id: approvePullRequest
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          repoPath: ${{ github.repository }}
+          gitHubHost: ${{ github.server_url }}
+          prPath: ${{ github.ref }}
+          releaseType: ${{ steps.releaseType.outputs.releaseType }}
+          commitMessage: ${{ steps.releaseType.outputs.commitMessage }}
+
+        run: .github/workflows/scripts/sanitize-commit/approve-pull-request.ps1

--- a/.github/workflows/scripts/release-and-publish/findNewVersion.ps1
+++ b/.github/workflows/scripts/release-and-publish/findNewVersion.ps1
@@ -1,0 +1,40 @@
+$RepositoryHost = $Env:RepositoryHost.Substring($Env:RepositoryHost.indexOf("/") + 1)
+$RepositoryURI = "$Env:RepositoryHost/$Env:RepositoryURI"
+$CurrentRelease = gh release view --repo $RepositoryURI --json name,tagName,createdAt,body | ConvertFrom-Json
+
+Write-Output "::notice::Latest release in this repository was a release with name: $($CurrentRelease.name), tag version: $($CurrentRelease.tagName)"
+
+$MajorVersionNumber = [int]$CurrentRelease.tagName.split(".")[0]
+$NormalVersionNumber = [int]$CurrentRelease.tagName.split(".")[1]
+$MinorVersionNumber = [int]$CurrentRelease.tagName.split(".")[2]
+
+$NewMinorVersionNumber = $MinorVersionNumber
+$NewNormalVersionNumber = $NormalVersionNumber
+$NewMajorVersionNumber = $MajorVersionNumber
+
+switch ($Env:ReleaseType) {
+  fix {
+    $NewMinorVersionNumber = $MinorVersionNumber + 1
+    Write-Output "::notice::Increasing minor version number from: $MinorVersionNumber to $NewMinorVersionNumber"
+  }
+  feat {
+    $NewNormalVersionNumber = $NormalVersionNumber + 1
+    $NewMinorVersionNumber = 0
+    Write-Output "::notice::Increasing middle version number from: $NormalVersionNumber to $NewNormalVersionNumber"
+    Write-Output "::notice::Resetting minor version number from: $MinorVersionNumber to $NewMinorVersionNumber"
+  }
+  breaking {
+    $NewMajorVersionNumber = $MajorVersionNumber + 1
+    $NewNormalVersionNumber = 0
+    $NewMinorVersionNumber = 0
+    Write-Output "::notice::Increasing major version number from: $MajorVersionNumber to $NewMajorVersionNumber"
+    Write-Output "::notice::Resetting middle version number from: $NormalVersionNumber to $NewNormalVersionNumber"
+    Write-Output "::notice::Resetting minor version number from: $MinorVersionNumber to $NewMinorVersionNumber"
+  }
+}
+
+$NewTagVersion = "$NewMajorVersionNumber.$NewNormalVersionNumber.$NewMinorVersionNumber"
+
+Write-Output "::notice::New version is: $NewTagVersion"
+
+Add-Content -Value "newVersionNumber=$NewTagVersion" -Path $Env:GITHUB_OUTPUT -Encoding utf8

--- a/.github/workflows/scripts/release-and-publish/uploadAfpantFilesToAzure.ps1
+++ b/.github/workflows/scripts/release-and-publish/uploadAfpantFilesToAzure.ps1
@@ -1,0 +1,8 @@
+New-Item -Path "./" -Name "actions-tmp" -ItemType "Directory" | Out-Null
+New-Item -Path "./actions-tmp" -Name "xslt" -ItemType "Directory" | Out-Null
+New-Item -Path "./actions-tmp" -Name "xsd" -ItemType "Directory" | Out-Null
+New-Item -Path "./actions-tmp" -Name "xml" -ItemType "Directory" | Out-Null
+Get-ChildItem -Path 'spesifikasjoner/afpant/' -Recurse -Include *.xslt | ForEach-Object -Process { Copy-Item $_.VersionInfo.FileName ./actions-tmp/xslt/ }
+Get-ChildItem -Path 'spesifikasjoner/afpant/' -Recurse -Include *.xsd | ForEach-Object -Process { Copy-Item $_.VersionInfo.FileName ./actions-tmp/xsd }
+Get-ChildItem -Path 'spesifikasjoner/afpant/' -Recurse -Include *.xml | ForEach-Object -Process { Copy-Item $_.VersionInfo.FileName ./actions-tmp/xml }
+Get-ChildItem -Path 'actions-tmp' -Recurse -Include "*.*" | ForEach-Object -Process { Write-Output "::notice::Uploading file: $($_.Name.Substring($_.Name.lastIndexOf('/') + 1))" }

--- a/.github/workflows/scripts/sanitize-commit/approve-pull-request.ps1
+++ b/.github/workflows/scripts/sanitize-commit/approve-pull-request.ps1
@@ -1,0 +1,23 @@
+#Find PR URL
+$mergeLessPRPath = $Env:prPath.Substring(0, $Env:prPath.indexOf("/merge")) #Trim off "/merge"
+$PullRequestUrl = "$Env:gitHubHost/$Env:repoPath/$($mergeLessPRPath.Substring($mergeLessPRPath.indexOf("pull/")))" #Combine to URL, remove "/refs" i.e only include "pull/<nr>"
+
+switch ($Env:releaseType) {
+  doc {
+    Write-Output "::notice::The latest commit indicates a documentation change. Merging this pull-request will not alter the version number."
+    gh pr comment $PullRequestUrl --body "The naming is confirmed. The latest commit indicates a documentation change. Merging this pull-request will not alter the version number."
+    exit 0
+  } fix {
+    Write-Output "::notice::The latest commit: $Env:commitMessage indicates a fix change. Merging this pull-request will increase the minor (0.0.x) version number."
+    gh pr comment $PullRequestUrl --body "The naming is confirmed. The latest commit: '$Env:commitMessage' indicates a fix change. Merging this pull-request will increase the minor (0.0.x) version number."
+    exit 0
+  } feat {
+    Write-Output "::notice::The latest commit: $Env:commitMessage indicates a non-breaking feature change. Merging this pull-request will increase the middle (0.x.0) version number."
+    gh pr comment $PullRequestUrl --body "The naming is confirmed. The latest commit: '$Env:commitMessage' indicates a non-breaking feature change. Merging this pull-request will increase the middle (0.x.0) version number."
+    exit 0
+  } breaking {
+    Write-Output "::notice::The latest commit: $Env:commitMessage indicates a breaking feature change. Merging this pull-request will increase the major (x.0.0) version number."
+    gh pr comment $PullRequestUrl --body "The naming is confirmed. The latest commit: '$Env:commitMessage' indicates a breaking feature change. Merging this pull-request will increase the major (x.0.0) version number."
+    exit 0
+  }
+}

--- a/.github/workflows/scripts/shared/determineReleaseType.ps1
+++ b/.github/workflows/scripts/shared/determineReleaseType.ps1
@@ -1,0 +1,53 @@
+$CommitMessage = ""
+# /////////// Determine commit message \\\\\\\\\\\\\\\\\\\\\\\
+if ( ($null -ne $Env:prPath) -and ($null -ne $Env:mergeCommitMessage) ) { #If booth methoods are present somthing is wrong
+  Write-Output "::error title=Script-Error::Both the 'prPath' and 'mergeCommitMessage' environment variables are used, this is wrong, check the pipeline workflow"
+} elseif ($null -ne $Env:prPath) { #If we have a Pull-Request Path that means that this was triggered by a pull-request, we need to find the last commit in the Pull-Request
+  #Find pull-request URL:
+  $mergeLessPRPath = $Env:prPath.Substring(0, $Env:prPath.indexOf("/merge")) #Trim off "/merge"
+  $PullRequestUrl = "$Env:gitHubHost/$Env:repoPath/$($mergeLessPRPath.Substring($mergeLessPRPath.indexOf("pull/")))" #Combine to URL, remove "/refs" i.e only include "pull/<nr>"
+
+  $CommitMessage = gh pr view $PullRequestUrl --json commits | ConvertFrom-Json | Select-Object -Expand commits | ForEach-Object { $_.messageHeadline } | Select-Object -Last 1
+
+  if ($CommitMessage -match '^Merge.*') { #If a merge conflict was solved the commit message might not follow the standard, jumping one up
+    Write-Output "::notify::The last commit on the pull request: $PullRequestUrl contained 'Merge' on the last commit message, this might be due to a merge-conflict resolution, checking previous to last commit message"
+    $CommitMessage = gh pr view $PullRequestUrl --json commits | ConvertFrom-Json | Select-Object -Expand commits | ForEach-Object { $_.messageHeadline } | Select-Object -Last 2 | Select-Object -First 1
+  }
+} elseif ($null -ne $Env:mergeCommitMessage) { #If this is not null, then the commit message was a merge commit message, we need to find the final commit message of the merge branch
+  if ( $Env:mergeCommitMessage -notmatch '^(Merge pull request #)[0-9]( from ).*') {
+    Write-Output "::error title=Script-Error::The script has encountered an error while attempting to find the release type. The script got the commit message as input, which means that this was called as part of a push to the master branch, but the commit message did not follow the regex pattern for a merge commit, this means that somone pushed straight to master. Naughty Naughty! The commit message was: $Env:mergeCommitMessage"
+    exit 1
+  } else { #Find the last Pull-Request commit message using the PR number from the commit message of the merge commit message
+    $NoAfterNumber = $Env:mergeCommitMessage.Substring(0, $Env:mergeCommitMessage.indexOf("from"))
+    [Int]$PullRequestNumber = $NoAfterNumber.Substring($NoAfterNumber.indexOf("#") + 1)
+    $PullRequestUrl = "$Env:gitHubHost/$Env:repoPath/pull/$PullRequestNumber"
+
+    $CommitMessage = gh pr view $PullRequestUrl --json commits | ConvertFrom-Json | Select-Object -Expand commits | ForEach-Object { $_.messageHeadline } | Select-Object -Last 1
+
+    if ($CommitMessage -match '^Merge.*') { #If a merge conflict was solved the commit message might not follow the standard, jumping one up
+      Write-Output "::notify::The last commit on the pull request: $PullRequestUrl contained 'Merge' on the last commit message, this might be due to a merge-conflict resolution, checking previous to last commit message"
+      $CommitMessage = gh pr view $PullRequestUrl --json commits | ConvertFrom-Json | Select-Object -Expand commits | ForEach-Object { $_.messageHeadline } | Select-Object -Last 2 | Select-Object -First 1
+    }
+  }
+} else {
+  Write-Output "::error title=Script-Error::Either the 'prPath' and 'mergeCommitMessage' environment variables must be included, found none."
+}
+
+#///////////////// Determine release type based on commit message. \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+if ( $CommitMessage -match '^doc:(\s|\S)*$') {
+  $releaseType = 'doc'
+} elseif ( $CommitMessage -match '^fix:(\s|\S)*$' ) {
+  $releaseType = 'fix'
+} elseif ( $CommitMessage -match '^feat:(\s|\S)*$' ) {
+  $releaseType = 'feat'
+} elseif ( $CommitMessage -match '^feat!:(\s|\S)*$' ) {
+  $releaseType = 'breaking'
+} else {
+  Write-Output "::error title=Naming-Convention-Error::The commit message did not follow the agreed upon naming convention, the name of the lates commit was: $CommitMessage"
+  exit 1
+}
+
+Write-Output "::notice::The merge was determined to be a $releaseType change"
+
+Add-Content -Value "releaseType=$releaseType" -Path $Env:GITHUB_OUTPUT -Encoding utf8
+Add-Content -Value "commitMessage=$CommitMessage" -Path $Env:GITHUB_OUTPUT -Encoding utf8


### PR DESCRIPTION
Da har jeg laget to GitHub workflows:

- En som kontrollerer commit messages for å sørge for at de inneholder enten doc, fix, feat eller feat!. Denne kjører hver gang noen oppretter eller gjør endring i en PR
- En som lager en ny release etter hva slags endring det er og deretter laster opp XML, XSD og XSLT filer til Azure CDNen for DSVE. Denne kjører hver gang noen merger inn til master (eller evt hvis noen dytter rett til master).

**Sanitize-commit**
Denne workflowen kjører hver gang en PR opprettes eller endres, den sjekker om siste commit melding starter med enten "doc", "fix", "feat" eller "feat!". Hvis den ikke gjør det feiler testen, og jeg vil konfigurere det slik at man ikke kan merge uten at denne er passert. Dersom testen passerer vil GitHub runneren legge inn en kommentar som sier at testen er passert og hva slags endring den oppdaget.

**release-and-publish**
Denne workflowen kjører hver gang noen pushes til master, i.e når noen merger noe inn i master. Den sjekker også at siste commit (evt commiten før der igjen dersom det kom en merge-conflict-resolution-commit) følger navngivingen. Den avgjør så om den skal øke siste, miderste eller første versjonstall og lager en ny release av seg selv. Når denne releasen er lagd laster den opp alle XML, XSD og XSLT filer i repoet til CDNen under denne nye versjonen altså vil den havne under: https://prod.cdn.dsop.no/dsve/v/<nytt versjonsnummer>/[xml|xslt|xsd].

Begge er testet i en fork jeg tok av dette repoet så jeg er rimelig sikker på at de vil fungere.