### PR TITLE
Ikke alle debitorer i pant trenger å være med i meglersaken

### DIFF
--- a/spesifikasjoner/afpant/afpant-kjøperspantedokument/afpant-kjøperspantedokument.md
+++ b/spesifikasjoner/afpant/afpant-kjøperspantedokument/afpant-kjøperspantedokument.md
@@ -30,11 +30,12 @@ Referansen settes ved opprettelse av dokumentet i "no.kartverket.grunnbok.wsapi.
 - Eksempler på gyldige referanser: [caseId]-[dokumentId]-[bankregisternummer] "12345-123456789-9057", [UUID] "a39e6076-b775-11ea-b3de-0242ac130004"
 	
 
-### teknisk-beskrivelse: ruting
-- mottakende systemleverandør søker blant alle sine kunders matrikkelenhet(er)
-- utvalget avgrenses til matrikkelenheter som tilhører meglersaker hvor organisasjonsnummeret til _enten_ meglerforetaket eller oppgjørsforetaket på meglersaken er lik organisasjonsnummeret pantedokumentet er sendt til ("reportee")
-- utvalget avgrenses til meglersaker hvor **alle debitorene i pantedokumentet også er registrert som kjøpere på meglersaken** (hvis det mangler fødselsnummer/orgnummer på kjøper(e) kan leverandør selv velge graden av fuzzy matching som skal tillates) 
-- dersom det er registrert flere kjøpere på meglersaken enn det finnes debitorer/signaturer i pantedokumentet skal mottakende system avvise forsendelsen med en SignedMortgageDeedProcessedMessage (NACK) hvor status = DebitorMismatch.
+### Teknisk-beskrivelse: Matching og routing
+- Mottakende systemleverandør søker blant alle sine kunders matrikkelenhet(er). 
+- Utvalget avgrenses til matrikkelenheter som tilhører meglersaker der organisasjonsnummeret til _enten_ meglerforetaket eller oppgjørsforetaket på meglersaken er lik organisasjonsnummeret pantedokumentet er sendt til ("reportee"). 
+- Utvalget begrenses til meglersaker hvor **minst en av debitorene i pantedokumentet må finnes som kjøpere i meglersaken**. (Dersom det mangler fødselsnummer eller organisasjonsnummer på kjøper(e), kan leverandøren selv bestemme graden av fuzzy matching som skal tillates)
+  - For eksempel, i eiendomshandler der en person kjøper seg inn i en bolig (andel), vil de eksisterende eier(e) av boligen være debitor(er) i pantedokumentet, og ikke kjøper(e) i meglersaken. Banken vil som regel hefte i hele eiendommen, noe som medfører at de eksisterende eier(e) vil være debitor(er) i pantedokumentet, og ikke kjøper(e) i meglersaken.
+- Dersom **ingen av debitorene i pantedokumentet er til stede som kjøper i meglersaken**, skal det mottakende systemet avvise forsendelsen med en SignedMortgageDeedProcessedMessage (NACK) der status = DebitorMismatch.
 
 ### Håndtering av feil
 - Den første feilen som oppstår stopper videre behandling av forsendelsen.

--- a/spesifikasjoner/afpant/afpant-kjøperspantedokument/readme.md
+++ b/spesifikasjoner/afpant/afpant-kjøperspantedokument/readme.md
@@ -6,6 +6,57 @@ Det sendes kvittering fra mottakersystem til avsendersystem med informasjon om f
 
 Når kjøpers pantedokument er tinglyst hos Kartverket, sendes det en melding fra megler til bank for å informere om at pantedokument er tinglyst.
 
+# Digital overføring av kjøpers pantedokument – forenklet forklaring
+
+Når en bolig kjøpes og finansieres med lån, må banken sende et pantedokument til tinglysing. Dette skjer digitalt og involverer både banken og eiendomsmegleren. Her er hvordan prosessen fungerer:
+
+---
+
+## 📦 Hva sender banken?
+
+Banken lager en digital forsendelse som inneholder:
+
+- **Kjøpers pantedokument** (SDO-format)
+- **Forutsetningsbrev** (valgfritt) – med informasjon om forutsetninger eller innbetaling
+
+Alt pakkes i en ZIP-fil og sendes via Altinn til megler eller oppgjørsforetak.
+
+---
+
+## 🧭 Hvordan vet banken hvor det skal sendes?
+
+- Banken henter **organisasjonsnummeret** til mottaker fra kjøpekontrakten.
+- Dette kan være eiendomsmeglerforetaket eller oppgjørsforetaket.
+
+---
+
+## 🧠 Hva gjør meglersystemet?
+
+- ZIP-filen pakkes ut.
+- Systemet leser pantedokumentet og forsøker å **matche** det med riktig eiendom og kjøper i meglersystemet.
+- Hvis alt stemmer, **rutes dokumentet til riktig sak**.
+- Hvis noe ikke stemmer (f.eks. feil kjøper), sendes en feilmelding (NACK) tilbake til banken.
+
+---
+
+## ✅ Hva skjer etterpå?
+
+- Megler bruker dokumentet i tinglysingen.
+- Banken får en **kvittering** (ACK eller NACK) som viser om dokumentet ble korrekt behandlet.
+
+---
+
+## 🔐 Hvorfor er dette viktig?
+
+- Sikrer at dokumentene havner hos riktig megler og sak
+- Gjør prosessen raskere og tryggere
+- Reduserer manuell håndtering og risiko for feil
+
+---
+
+> Denne digitale prosessen gjør det enklere og mer effektivt å håndtere pantedokumenter i eiendomshandler.
+
+
 ## Dokumentasjon
 - [Oversendelse av pantedokument - teknisk beskrivelse](./afpant-kj%C3%B8perspantedokument.md)
 


### PR DESCRIPTION
Endret tekst i afpant-kjøperspantedokument.md

For å matche et pantedokument mot en _meglersak_ holder det med at en debitor i pantedokumentet finnes i meglersaken.

>For eksempel, i eiendomshandler der en person kjøper seg inn i en bolig (andel), vil de eksisterende eier(e) av boligen være debitor(er) i pantedokumentet, og ikke kjøper(e) i meglersaken. Banken vil som regel hefte i hele eiendommen, noe som medfører at de eksisterende eier(e) vil være debitor(er) i pantedokumentet, og ikke kjøper(e) i meglersaken.

La til en litt mer funksjonell beskrivelse i readme.md (.. eller ai'en gjorde det)