### PR TITLE
fix: Vise desimaler for beløper

### DIFF
--- a/spesifikasjoner/afpant/afpant-model/xslt/restgjeld.xslt
+++ b/spesifikasjoner/afpant/afpant-model/xslt/restgjeld.xslt
@@ -248,7 +248,7 @@
         <xsl:if test="string-length($prefix) &gt; 0">
             <xsl:value-of select="$prefix"/>
         </xsl:if>
-        <xsl:value-of select="format-number(number($numericValue), '### ### ### ###', 'nb-no-space')"/>
+        <xsl:value-of select="format-number(number($numericValue), '### ### ### ###,00', 'nb-no-space')"/>
     </xsl:template>
     <xsl:template name="formatPhoneNumber">
         <xsl:param name="prefix"/>


### PR DESCRIPTION
Ører ble ikke vist for beløper. Har lagt til ",00" for å vise med to desimaler.