### PR TITLE
feat: Mulig å ha med liste av lån som er knyttet til pantedokumentet

### DIFF
--- a/spesifikasjoner/afpant/afpant-kjøperspantedokument/afpant-forutsetningsbrev/afpant-forutsetningsbrev-eksempel_betalingsmelding.xml
+++ b/spesifikasjoner/afpant/afpant-kjøperspantedokument/afpant-forutsetningsbrev/afpant-forutsetningsbrev-eksempel_betalingsmelding.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<?xml-stylesheet type="text/xsl" href="https://prod.cdn.dsop.no/dsve/v/2.0.0/xslt/afpant-forutsetningsbrev.xslt"?>
+<?xml-stylesheet type="text/xsl" href="./afpant-forutsetningsbrev.xslt"?>
 <Forutsetningsbrev xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Kreditor>
     <Nummer>123456789</Nummer>
@@ -55,7 +55,7 @@
     <BeloepOverforesDato>2019-01-23</BeloepOverforesDato>
     <TotalBeloep>2500000</TotalBeloep>
     <TilKontonummer>65501100000</TilKontonummer>
-    <KID>10001000222111</KID>
+    <Betalingsmelding>Merk innbetaling med: AF123M7</Betalingsmelding>
     <KreditorSaksnummer>Lånesak 124-221/22</KreditorSaksnummer>
     <MeglerSaksnummer>117-00-1002 Lånegaten 15 B</MeglerSaksnummer>
     <BeloepGjelder>dekning av kjøpesum for ovennevnte eiendom</BeloepGjelder>

--- a/spesifikasjoner/afpant/afpant-kjøperspantedokument/afpant-forutsetningsbrev/afpant-forutsetningsbrev.xsd
+++ b/spesifikasjoner/afpant/afpant-kjøperspantedokument/afpant-forutsetningsbrev/afpant-forutsetningsbrev.xsd
@@ -131,6 +131,9 @@ Informasjon om innbetalingen (beløp, totalbeløp, mottakerkontonummer og kid) b
     </xs:restriction>
   </xs:simpleType>
   <xs:complexType name="Overfoersel">
+    <xs:annotation>
+      <xs:documentation>Overføringsdetaljer. Kan ikke angi både KID og betalingsmelding.</xs:documentation>
+    </xs:annotation>
     <xs:sequence>
       <xs:element minOccurs="1" maxOccurs="1" name="Beloep" type="xs:double">
           <xs:annotation>
@@ -149,6 +152,7 @@ Informasjon om innbetalingen (beløp, totalbeløp, mottakerkontonummer og kid) b
       </xs:element>
       <xs:element minOccurs="1" maxOccurs="1" name="TilKontonummer" type="xs:string" />
       <xs:element minOccurs="0" maxOccurs="1" name="KID" type="xs:string" />
+      <xs:element minOccurs="0" maxOccurs="1" name="Betalingsmelding" type="xs:string" />
       <xs:element minOccurs="0" maxOccurs="1" name="KreditorSaksnummer" type="xs:string">
           <xs:annotation>
               <xs:documentation>Kan angi f.eks lånesaksnummer eller referanse i (bank)fagsystem</xs:documentation>

--- a/spesifikasjoner/afpant/afpant-kjøperspantedokument/afpant-forutsetningsbrev/afpant-forutsetningsbrev.xslt
+++ b/spesifikasjoner/afpant/afpant-kjøperspantedokument/afpant-forutsetningsbrev/afpant-forutsetningsbrev.xslt
@@ -196,6 +196,12 @@
                   <xsl:value-of select="OverfoerselDetaljer/KID"/>
                 </td>
               </tr>
+              <tr>
+                <td>Betalingsmelding</td>
+                <td>
+                  <xsl:value-of select="OverfoerselDetaljer/Betalingsmelding"/>
+                </td>
+              </tr>
               <xsl:if test="string-length(OverfoerselDetaljer/MeglerSaksnummer) &gt; 0">
                 <tr>
                   <td>Oppdragsnummer megler</td>

--- a/spesifikasjoner/afpant/afpant-kjøperspantedokument/afpant-forutsetningsbrev/forutsetningsbrev.md
+++ b/spesifikasjoner/afpant/afpant-kjøperspantedokument/afpant-forutsetningsbrev/forutsetningsbrev.md
@@ -122,3 +122,8 @@ tilbake.
 Dersom bank mot formodning ikke kan sende forutsetningene som strukturerte data, må brevet
 skrives ut og sendes per post (eventuelt per e-post). Det vil være angitt i oversendingen at man kan
 forvente et forutsetningsbrev på annet format, i annen kanal.
+
+# Endring i spesifikasjonen 2026-04-27
+På teknisk møte i DSVE 27. april 2026 ble partene enige om at vi skulle legge til et nytt, frivillig felt i 
+overføringsdetaljene for å kunne angi en betalingsmelding når det brukes istedenfor KID. Skal ikke være et krav at dette feltet må fylles
+ut, men man skal ikke fylle ut både KID og betalingsmelding.

--- a/spesifikasjoner/afpant/afpant-model/examples/innfrielsessaldosvar_1.2.xml
+++ b/spesifikasjoner/afpant/afpant-model/examples/innfrielsessaldosvar_1.2.xml
@@ -1,0 +1,69 @@
+<?xml-stylesheet type="text/xsl" href="../xslt/restgjeld.xslt"?>
+<innfrielsessaldosvar xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../xsd/dsve.xsd">
+  <avsender id="984851006">
+    <foretaksnavn>DNB BANK ASA</foretaksnavn>
+    <kontaktperson>
+      <navn>Ole Bankesen</navn>
+      <epost>ole@dnb.no</epost>
+      <telefondirekte>41414141</telefondirekte>
+      <telefon>22224455</telefon>
+    </kontaktperson>
+    <referanse>FX12398731273123</referanse>
+  </avsender>
+  <mottaker id="910968955">
+    <foretaksnavn>DNB EIENDOM AS</foretaksnavn>
+    <referanse>OPGNR-123</referanse>
+  </mottaker>
+  <laanliste>
+    <laan>
+      <laantakerIkkeHjemmelshaver>false</laantakerIkkeHjemmelshaver>
+      <transporterklaering>true</transporterklaering>
+      <laanenummer>91582722531</laanenummer>
+      <kontonummer>91582722531</kontonummer>
+      <saldoerPerDato>
+        <saldoPerDato>
+          <beloep>12345000</beloep>
+          <dato>2025-05-17</dato>
+        </saldoPerDato>
+        <saldoPerDato>
+          <beloep>123456</beloep>
+          <dato>2025-05-16</dato>
+        </saldoPerDato>
+      </saldoerPerDato>
+      <laantakereHjemmelshaver>
+        <navn>Kari Nordmann</navn>
+      </laantakereHjemmelshaver>
+    </laan>
+    <laan>
+      <laantakerIkkeHjemmelshaver>true</laantakerIkkeHjemmelshaver>
+      <transporterklaering>false</transporterklaering>
+      <laanenummer>92610464159</laanenummer>
+      <kontonummer>92610464159</kontonummer>
+      <saldoerPerDato>
+        <saldoPerDato>
+          <beloep>23123</beloep>
+          <dato>2025-05-17</dato>
+        </saldoPerDato>
+        <saldoPerDato>
+          <beloep>43213</beloep>
+          <dato>2025-05-16</dato>
+        </saldoPerDato>
+      </saldoerPerDato>
+      <laantakereHjemmelshaver>
+        <navn>Kari Nordmann</navn>
+      </laantakereHjemmelshaver>
+    </laan>
+  </laanliste>
+  <registerenheterMedDokumentreferanser>
+    <registerenhetMedDokumentreferanse>
+      <matrikkel kommunenavn="Lillestrøm" kommunenummer="3205" gaardsnummer="273" bruksnummer="220" festenummer="0" seksjonsnummer="12" eiendomsnivaa="E"/>
+      <pantedokumentreferanser>
+        <pantedokumentreferanse dokumentnummer="3" dokumentaar="2024" embetenummer="201" rettsstiftelsesnummer="1" registreringstidspunkt="2024-01-10T19:00:47+01:00" beloep="3500000">
+          <!-- Liste over laanenummer som pantet er knyttet til -->
+          <laanenummer>92610464159</laanenummer>
+          <laanenummer>91582722531</laanenummer>
+        </pantedokumentreferanse>
+      </pantedokumentreferanser>
+    </registerenhetMedDokumentreferanse>
+  </registerenheterMedDokumentreferanser>
+</innfrielsessaldosvar>

--- a/spesifikasjoner/afpant/afpant-model/examples/restgjeldssvar_1.2.xml
+++ b/spesifikasjoner/afpant/afpant-model/examples/restgjeldssvar_1.2.xml
@@ -1,0 +1,52 @@
+<?xml-stylesheet type="text/xsl" href="../xslt/restgjeld.xslt"?>
+<restgjeldssvar xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../xsd/dsve.xsd">
+  <avsender id="984851006">
+    <foretaksnavn>DNB BANK ASA</foretaksnavn>
+    <kontaktperson>
+      <navn>Ole Bankesen</navn>
+      <epost>ole@dnb.no</epost>
+      <telefondirekte>41414141</telefondirekte>
+      <telefon>22224455</telefon>
+    </kontaktperson>
+    <referanse>FX12398731273123</referanse>
+  </avsender>
+  <mottaker id="910968955">
+    <foretaksnavn>DNB EIENDOM AS</foretaksnavn>
+    <referanse>OPGNR-123</referanse>
+  </mottaker>
+  <laanliste>
+    <laan>
+      <rammelaan>true</rammelaan>
+      <oevreGrenseRammelaan>12341234</oevreGrenseRammelaan>
+      <fastrente>false</fastrente>
+      <realkausjon>false</realkausjon>
+      <laantakerIkkeHjemmelshaver>true</laantakerIkkeHjemmelshaver>
+      <transporterklaering>false</transporterklaering>
+      <laanenummer>92610464159</laanenummer>
+      <kontonummer>92610464159</kontonummer>
+      <saldo>1000.20</saldo>
+      <laantakereHjemmelshaver>
+        <navn>Ola Normann</navn>
+        <navn>Kari Normann</navn>
+      </laantakereHjemmelshaver>
+    </laan>
+  </laanliste>
+  <registerenheterMedDokumentreferanser>
+    <registerenhetMedDokumentreferanse>
+      <matrikkel kommunenavn="Lillestrøm" kommunenummer="3205" gaardsnummer="273" bruksnummer="220" festenummer="0" seksjonsnummer="12" eiendomsnivaa="E"/>
+      <pantedokumentreferanser>
+        <pantedokumentreferanse dokumentnummer="3" dokumentaar="1998" embetenummer="200" rettsstiftelsesnummer="1" registreringstidspunkt="1998-01-02T07:00:47+01:00" beloep="3500000">
+          <!-- Liste over laanenummer som pantet er knyttet til -->
+          <laanenummer>92610464159</laanenummer>
+          <laanenummer>91582722531</laanenummer>
+        </pantedokumentreferanse>
+        <pantedokumentreferanse dokumentnummer="234123" dokumentaar="2024" embetenummer="201" rettsstiftelsesnummer="1" registreringstidspunkt="2024-01-10T19:00:47+01:00" beloep="125000">
+          <!-- Liste over laanenummer som pantet er knyttet til -->
+          <laanenummer>92610464159</laanenummer>
+          <laanenummer>91582722531</laanenummer>
+        </pantedokumentreferanse>
+      </pantedokumentreferanser>
+    </registerenhetMedDokumentreferanse>
+  </registerenheterMedDokumentreferanser>
+  <sperretForVidereOpplaan>true</sperretForVidereOpplaan>
+</restgjeldssvar>

--- a/spesifikasjoner/afpant/afpant-model/examples/restgjeldssvar_1.2.xml
+++ b/spesifikasjoner/afpant/afpant-model/examples/restgjeldssvar_1.2.xml
@@ -1,0 +1,46 @@
+<?xml-stylesheet type="text/xsl" href="../xslt/restgjeld.xslt"?>
+<restgjeldssvar xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../xsd/dsve.xsd">
+  <avsender id="984851006">
+    <foretaksnavn>DNB BANK ASA</foretaksnavn>
+    <kontaktperson>
+      <navn>Ole Bankesen</navn>
+      <epost>ole@dnb.no</epost>
+      <telefondirekte>41414141</telefondirekte>
+      <telefon>22224455</telefon>
+    </kontaktperson>
+    <referanse>FX12398731273123</referanse>
+  </avsender>
+  <mottaker id="910968955">
+    <foretaksnavn>DNB EIENDOM AS</foretaksnavn>
+    <referanse>OPGNR-123</referanse>
+  </mottaker>
+  <laanliste>
+    <laan>
+      <rammelaan>true</rammelaan>
+      <oevreGrenseRammelaan>12341234</oevreGrenseRammelaan>
+      <fastrente>false</fastrente>
+      <realkausjon>false</realkausjon>
+      <laantakerIkkeHjemmelshaver>true</laantakerIkkeHjemmelshaver>
+      <transporterklaering>false</transporterklaering>
+      <laanenummer>92610464159</laanenummer>
+      <kontonummer>92610464159</kontonummer>
+      <saldo>1000.20</saldo>
+      <laantakereHjemmelshaver>
+        <navn>Ola Normann</navn>
+        <navn>Kari Normann</navn>
+      </laantakereHjemmelshaver>
+    </laan>
+  </laanliste>
+  <registerenheterMedDokumentreferanser>
+    <registerenhetMedDokumentreferanse>
+      <matrikkel kommunenavn="Lillestrøm" kommunenummer="3205" gaardsnummer="273" bruksnummer="220" festenummer="0" seksjonsnummer="12" eiendomsnivaa="E"/>
+      <pantedokumentreferanser>
+        <pantedokumentreferanse dokumentnummer="3" dokumentaar="2024" embetenummer="201" rettsstiftelsesnummer="1" registreringstidspunkt="2024-01-10T19:00:47+01:00" beloep="3500000">
+          <!-- Liste over laanenummer som pantet er knyttet til -->
+          <laanenummer>92610464159</laanenummer>
+        </pantedokumentreferanse>
+      </pantedokumentreferanser>
+    </registerenhetMedDokumentreferanse>
+  </registerenheterMedDokumentreferanser>
+  <sperretForVidereOpplaan>true</sperretForVidereOpplaan>
+</restgjeldssvar>

--- a/spesifikasjoner/afpant/afpant-model/examples/restgjeldssvar_1.2.xml
+++ b/spesifikasjoner/afpant/afpant-model/examples/restgjeldssvar_1.2.xml
@@ -35,9 +35,15 @@
     <registerenhetMedDokumentreferanse>
       <matrikkel kommunenavn="Lillestrøm" kommunenummer="3205" gaardsnummer="273" bruksnummer="220" festenummer="0" seksjonsnummer="12" eiendomsnivaa="E"/>
       <pantedokumentreferanser>
-        <pantedokumentreferanse dokumentnummer="3" dokumentaar="2024" embetenummer="201" rettsstiftelsesnummer="1" registreringstidspunkt="2024-01-10T19:00:47+01:00" beloep="3500000">
+        <pantedokumentreferanse dokumentnummer="3" dokumentaar="1998" embetenummer="200" rettsstiftelsesnummer="1" registreringstidspunkt="1998-01-02T07:00:47+01:00" beloep="3500000">
           <!-- Liste over laanenummer som pantet er knyttet til -->
           <laanenummer>92610464159</laanenummer>
+          <laanenummer>91582722531</laanenummer>
+        </pantedokumentreferanse>
+        <pantedokumentreferanse dokumentnummer="234123" dokumentaar="2024" embetenummer="201" rettsstiftelsesnummer="1" registreringstidspunkt="2024-01-10T19:00:47+01:00" beloep="125000">
+          <!-- Liste over laanenummer som pantet er knyttet til -->
+          <laanenummer>92610464159</laanenummer>
+          <laanenummer>91582722531</laanenummer>
         </pantedokumentreferanse>
       </pantedokumentreferanser>
     </registerenhetMedDokumentreferanse>

--- a/spesifikasjoner/afpant/afpant-model/xsd/dsve.xsd
+++ b/spesifikasjoner/afpant/afpant-model/xsd/dsve.xsd
@@ -893,13 +893,20 @@
     <xs:annotation>
       <xs:documentation>Beløp er opprinnelig tinglyst beløp i hele kroner.</xs:documentation>
     </xs:annotation>
+    <xs:sequence>
+      <xs:element name="laanenummer" minOccurs="0" maxOccurs="unbounded" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Liste over lånenummer som pantet er knyttet mot. En tom/manglende lite med lånenumre betyr at lånet er nedbetalt men pantedokumentet ikke er slettet enda.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
     <xs:attribute name="dokumentnummer" type="Dokumentnummer" use="required"/>
     <xs:attribute name="dokumentaar" type="Aar" use="required"/>
     <xs:attribute name="embetenummer" type="Embetenummer" use="required"/>
     <xs:attribute name="rettsstiftelsesnummer" type="Rettsstiftelsesnummer" use="required"/>
     <xs:attribute name="registreringstidspunkt" type="xs:dateTime" use="optional"/>
-    <xs:attribute name="beloep" type="Pantedokumentbeloep" use="optional">
-    </xs:attribute>
+    <xs:attribute name="beloep" type="Pantedokumentbeloep" use="optional"/>
   </xs:complexType>
 
   <xs:complexType name="Metadata">

--- a/spesifikasjoner/afpant/afpant-model/xsd/dsve.xsd
+++ b/spesifikasjoner/afpant/afpant-model/xsd/dsve.xsd
@@ -893,13 +893,21 @@
     <xs:annotation>
       <xs:documentation>Beløp er opprinnelig tinglyst beløp i hele kroner.</xs:documentation>
     </xs:annotation>
+    <xs:sequence>
+      <xs:element name="laanenummer" minOccurs="0" maxOccurs="unbounded" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Liste over lånenummer som pantet er knyttet mot. Hvis listen er tom, vet ikke megler om lånet er nedbetalt eller om
+            banken ikke har støtte for å hente ut denne informasjonen/koblingen.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
     <xs:attribute name="dokumentnummer" type="Dokumentnummer" use="required"/>
     <xs:attribute name="dokumentaar" type="Aar" use="required"/>
     <xs:attribute name="embetenummer" type="Embetenummer" use="required"/>
     <xs:attribute name="rettsstiftelsesnummer" type="Rettsstiftelsesnummer" use="required"/>
     <xs:attribute name="registreringstidspunkt" type="xs:dateTime" use="optional"/>
-    <xs:attribute name="beloep" type="Pantedokumentbeloep" use="optional">
-    </xs:attribute>
+    <xs:attribute name="beloep" type="Pantedokumentbeloep" use="optional"/>
   </xs:complexType>
 
   <xs:complexType name="Metadata">

--- a/spesifikasjoner/afpant/afpant-model/xslt/restgjeld.xslt
+++ b/spesifikasjoner/afpant/afpant-model/xslt/restgjeld.xslt
@@ -666,6 +666,20 @@
         <br/>
       </div>
     </div>
+    <xsl:if test="$dokument/laanenummer">
+      <div class="rad">
+        <div class="celle kol1">
+          <span>Lånenummer:</span>
+        </div>
+        <div class="celle">
+          <xsl:for-each select="$dokument/laanenummer">
+            <div>
+              <xsl:value-of select="."/>
+            </div>
+          </xsl:for-each>
+        </div>
+      </div>
+    </xsl:if>
   </xsl:template>
   <xsl:template name="seksjon">
     <xsl:param name="tittel"/>

--- a/spesifikasjoner/afpant/afpant-restgjeld/restgjeldsoppgave-og-innfrielsessaldo-teknisk-beskrivelse.md
+++ b/spesifikasjoner/afpant/afpant-restgjeld/restgjeldsoppgave-og-innfrielsessaldo-teknisk-beskrivelse.md
@@ -52,6 +52,27 @@ En aktør kan være registrert for både sending og mottak av samme meldingstype
 En xml-fil av modell **Restgjeldsforespoersel** som er i henhold til [definert skjema.](../afpant-model/xsd/dsve.xsd).  
 Navnet på filen må følge konvensjonen "restgjeldsforespoersel_*.xml". Case er ikke sensitivt.
 
+
+## Kobling mellom lån og tinglyst dokument
+Endring: april 2026
+
+For å kunne oppdatere oppdraget i meglersystemet automatisk er det behov for å kunne koble riktig lån til riktig pantedokument hvis det er mer enn ett lån eller pantedokument hos banken.
+I restgjeldssvar og innfrielsessaldosvar er det derfor lagt til en liste med lånenummer under hver dokumentreferanse. Her kan banken liste ut ett eller flere lånenummer som er knyttet til det aktuelle pantedokumentet.
+Dersom banken ikke kan levere denne koblingen er det mulig å ikke fylle ut denne informasjonen, men da vil ikke megler kunne skille på:
+ 1 - Om det ikke er lån knyttet til det aktuelle pantedokumentet fordi lånet er nedbetalt og pantedokumentet ikke er slettet
+ 2 - Om banken ikke klarer å levere koblingen mellom lån og pantedokument.
+
+```xml
+<pantedokumentreferanser>
+  <pantedokumentreferanse dokumentnummer="3" dokumentaar="2024" embetenummer="201" rettsstiftelsesnummer="1" registreringstidspunkt="2024-01-10T19:00:47+01:00" beloep="3500000">
+    <!-- Liste over laanenummer som pantet er knyttet til. 0, 1 eller flere -->
+    <laanenummer>92610464159</laanenummer>
+    <laanenummer>91582722531</laanenummer>
+  </pantedokumentreferanse>
+</pantedokumentreferanser>
+```
+Eksempel hvoe det kan angis 0, 1 eller flere lånenummer knyttet til et pantedokument.
+
 ## Restgjeldssvar
 
 ### Retur av ACK/NACK notification fra fagsystem tilbake til requester (Megler/Bank) etter behandling av mottatt forespørsel:


### PR DESCRIPTION
For hvert pantedokumentreferanse er det nå mulig å legge ved en liste med lånenummer som pantedokumentet er koblet mot. Listen kan inneholde null , en eller flere lånenummer. Det at meglerne får denne informasjonen gjør det mulig å skrive data automatisk tilbake til meglersystemet i større grad.

Har lagt til mulighet for å angi Betalingsmelding i Forutsetningsbrevet slik vi avtalte i møtet 27. april 2026