### PR TITLE
feat: Flytte realkausjon

### DIFF
--- a/spesifikasjoner/afpant/afpant-model/examples/restgjeldssvar_1.0.xml
+++ b/spesifikasjoner/afpant/afpant-model/examples/restgjeldssvar_1.0.xml
@@ -1,5 +1,5 @@
 <?xml-stylesheet type="text/xsl" href="../xslt/restgjeld.xslt"?>
-<restgjeldssvar>
+<restgjeldssvar  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../xsd/dsve.xsd">
   <avsender id="984851006">
     <foretaksnavn>DNB BANK ASA</foretaksnavn>
     <kontaktperson>
@@ -20,7 +20,6 @@
       <rammelaan>true</rammelaan>
       <oevreGrenseRammelaan>12341234</oevreGrenseRammelaan>
       <fastrente>false</fastrente>
-      <realkausjon>false</realkausjon>
       <laantakerIkkeHjemmelshaver>true</laantakerIkkeHjemmelshaver>
       <transporterklaering>false</transporterklaering>
       <laanenummer>12342133341</laanenummer>
@@ -41,7 +40,6 @@
     <laan>
       <rammelaan>false</rammelaan>
       <fastrente>true</fastrente>
-      <realkausjon>true</realkausjon>
       <laantakerIkkeHjemmelshaver>true</laantakerIkkeHjemmelshaver>
       <transporterklaering>false</transporterklaering>
       <laanenummer>12342133342</laanenummer>
@@ -62,7 +60,6 @@
     <laan>
       <rammelaan>false</rammelaan>
       <fastrente>false</fastrente>
-      <realkausjon>true</realkausjon>
       <laantakerIkkeHjemmelshaver>false</laantakerIkkeHjemmelshaver>
       <transporterklaering>true</transporterklaering>
       <laanenummer>12342133343</laanenummer>
@@ -83,7 +80,6 @@
       <rammelaan>true</rammelaan>
       <oevreGrenseRammelaan>12341234</oevreGrenseRammelaan>
       <fastrente>false</fastrente>
-      <realkausjon>false</realkausjon>
       <laantakerIkkeHjemmelshaver>true</laantakerIkkeHjemmelshaver>
       <transporterklaering>false</transporterklaering>
       <laanenummer>12342133345</laanenummer>
@@ -104,7 +100,6 @@
       <rammelaan>true</rammelaan>
       <oevreGrenseRammelaan>12341234</oevreGrenseRammelaan>
       <fastrente>false</fastrente>
-      <realkausjon>false</realkausjon>
       <laantakerIkkeHjemmelshaver>true</laantakerIkkeHjemmelshaver>
       <transporterklaering>false</transporterklaering>
       <laanenummer>12342133345</laanenummer>
@@ -125,7 +120,6 @@
       <rammelaan>true</rammelaan>
       <oevreGrenseRammelaan>12341234</oevreGrenseRammelaan>
       <fastrente>false</fastrente>
-      <realkausjon>false</realkausjon>
       <laantakerIkkeHjemmelshaver>true</laantakerIkkeHjemmelshaver>
       <transporterklaering>false</transporterklaering>
       <laanenummer>12342133345</laanenummer>
@@ -146,7 +140,6 @@
       <rammelaan>true</rammelaan>
       <oevreGrenseRammelaan>12341234</oevreGrenseRammelaan>
       <fastrente>false</fastrente>
-      <realkausjon>false</realkausjon>
       <laantakerIkkeHjemmelshaver>true</laantakerIkkeHjemmelshaver>
       <transporterklaering>false</transporterklaering>
       <laanenummer>12342133345</laanenummer>
@@ -167,7 +160,6 @@
       <rammelaan>true</rammelaan>
       <oevreGrenseRammelaan>12341234</oevreGrenseRammelaan>
       <fastrente>false</fastrente>
-      <realkausjon>false</realkausjon>
       <laantakerIkkeHjemmelshaver>true</laantakerIkkeHjemmelshaver>
       <transporterklaering>false</transporterklaering>
       <laanenummer>12342133345</laanenummer>
@@ -221,4 +213,5 @@
     </registerenhetMedDokumentreferanse>
   </registerenheterMedDokumentreferanser>
   <sperretForVidereOpplaan>true</sperretForVidereOpplaan>
+  <realkausjon>true</realkausjon>
 </restgjeldssvar>

--- a/spesifikasjoner/afpant/afpant-model/xsd/dsve.xsd
+++ b/spesifikasjoner/afpant/afpant-model/xsd/dsve.xsd
@@ -115,6 +115,7 @@
         Liste med de pantedokumentene, per eiendom, som banken sletter om listen med lån innfris.
         Angivelse av om lånene er sperret for videre opplån eller ikke, og om panterettigheter blir slettet om lånene
         innfris.
+        Realkausjon er true hvis eiendom som selges er brukt som sikkerhet for lån hvor hjemmelsjaver ikke er med- eller låntaker.
       </xs:documentation>
     </xs:annotation>
     <xs:sequence>
@@ -123,6 +124,7 @@
       <xs:element minOccurs="1" maxOccurs="1" name="laanliste" type="LaanRestgjeldListe"/>
       <xs:element minOccurs="1" maxOccurs="1" name="registerenheterMedDokumentreferanser" type="RegisterenheterMedDokumentreferanse"/>
       <xs:element minOccurs="1" maxOccurs="1" name="sperretForVidereOpplaan" type="xs:boolean"/>
+      <xs:element minOccurs="1" maxOccurs="1" name="realkausjon" type="xs:boolean"/>
     </xs:sequence>
   </xs:complexType>
 
@@ -154,7 +156,6 @@
         Hvis ikke kid-nummer eller betalingsmelding er nødvendig kan begge utelates.
         Dersom lånenummer er likt kontonummer legges samme data i begge felter.
         Øvre grense for rammelån er kun brukt dersom det er rammelån.
-        Realkausjon er true hvis det er realkausjon i bildet
         laantakerIkkeHjemmelshaver er true dersom det finnes en eller flere låntakere som ikke er hjemmelshavere.
         laantakereHjemmelshaver er en liste med navn på de låntakerne som ogsp er hjemmelshavere.
         transporterklaering er true dersom det er et lån brukt til mellomfinansiering (transporterklæring)
@@ -165,7 +166,6 @@
       <xs:element minOccurs="1" maxOccurs="1" name="rammelaan" type="xs:boolean"/>
       <xs:element minOccurs="0" maxOccurs="1" name="oevreGrenseRammelaan" type="xs:double"/>
       <xs:element minOccurs="1" maxOccurs="1" name="fastrente" type="xs:boolean"/>
-      <xs:element minOccurs="1" maxOccurs="1" name="realkausjon" type="xs:boolean"/>
       <xs:element minOccurs="1" maxOccurs="1" name="laantakerIkkeHjemmelshaver" type="xs:boolean"/>
       <xs:element minOccurs="1" maxOccurs="1" name="transporterklaering" type="xs:boolean"/>
       <xs:element minOccurs="1" maxOccurs="1" name="laanenummer" type="xs:string"/>

--- a/spesifikasjoner/afpant/afpant-model/xslt/restgjeld.xslt
+++ b/spesifikasjoner/afpant/afpant-model/xslt/restgjeld.xslt
@@ -195,6 +195,7 @@
     </xsl:call-template>
     <xsl:call-template name="laan"/>
     <xsl:apply-templates select="sperretForVidereOpplaan"/>
+    <xsl:apply-templates select="realkausjon"/>
     <xsl:call-template name="avsender"/>
     <hr/>
   </xsl:template>
@@ -336,6 +337,18 @@
     <div class="hovedseksjon">
       <xsl:call-template name="seksjon">
         <xsl:with-param name="tittel" select="'Sperret for videre opplån'"/>
+      </xsl:call-template>
+      <div class="innhold">
+        <xsl:call-template name="yesNo">
+          <xsl:with-param name="booleanValue" select="."/>
+        </xsl:call-template>
+      </div>
+    </div>
+  </xsl:template>
+  <xsl:template match="realkausjon">
+    <div class="hovedseksjon">
+      <xsl:call-template name="seksjon">
+        <xsl:with-param name="tittel" select="'Realkausjon'"/>
       </xsl:call-template>
       <div class="innhold">
         <xsl:call-template name="yesNo">
@@ -740,16 +753,6 @@
                     <td>
                       <xsl:call-template name="yesNo">
                         <xsl:with-param name="booleanValue" select="fastrente"/>
-                      </xsl:call-template>
-                    </td>
-                  </tr>
-                </xsl:if>
-                <xsl:if test="realkausjon">
-                  <tr>
-                    <td>Realkausjon</td>
-                    <td>
-                      <xsl:call-template name="yesNo">
-                        <xsl:with-param name="booleanValue" select="realkausjon"/>
                       </xsl:call-template>
                     </td>
                   </tr>

--- a/spesifikasjoner/afpant/afpant-restgjeld/restgjeldsoppgave-og-innfrielsessaldo-teknisk-beskrivelse.md
+++ b/spesifikasjoner/afpant/afpant-restgjeld/restgjeldsoppgave-og-innfrielsessaldo-teknisk-beskrivelse.md
@@ -209,3 +209,36 @@ Navnet på filen må følge konvensjonen "innfrielsessaldoforespoersel_*.xml". C
 		</tr>
 	</tbody>
 </table>
+
+# Eksemple på utfylling av restgjeldssvar fra bank
+
+For å gjøre eksemplene enklere brukes scenarier hvor foreldre bruker sin eiendom som sikkerhet for lån hvor barna har kjøpt egen eiendom. For enkelthetsskyld skilles det ikke her mellom låntaker og medlåntaker
+da dette er en teknisk ting i banksystemet og ikke betyr noe for utfyllingen av svaret
+
+
+## Foreldre selger og er ikke låntakere
+
+Når eiendom som selges er brukt utelukkende som sikring for tredjepartslån (realkausjon) og hjemmelshaverne (som selger) ikke er låntaker, vil banken sende dokumentreferansen tilbake i svaret, men ikke avgi noe
+informasjon om lånet. Pantedokumentet som er sikringsdokument vil da ikke være koblet mot noen lån knyttet til hjemmelshaverne som selger. Lånet vil da ikke være med i svaret og dokumentet vil ikke være 
+knyttet mot lånenummeret. Feltet for realkausjon vil ha verdien `true` som signaliserer til megler at saken må følges opp. 
+
+
+## Foreldre som selger også er låntakere
+
+Når eiendom som selges er brukt som sikring og hjemmelshaverne (som selger) også er med- eller låntaker, vil banken sende dokumentreferansen og låneinformasjon tilbake i svaret.
+Pantedokumentet som er sikringsdokument er koblet mot lånet, barnas navn vil stå i listen over låntakere som ikke er hjemmelshaver, og feltet for realkausjon vil ha verdien `false`. 
+
+## Barna selger og foreldre er ikke låntakere, to pantedokumenter
+
+Med to pantedokumenter menes her at det er forskjellige pantedokumenter som hefter i barnas og foreldrenes eiendom som sikkerhet for barnas lån i banken. 
+Pantedokument tinglyst på foreldres eiendom blir ikke oppgitt i svaret da det ikke er tinglyst på barnas eiendom som selges. Lånet som banken oppgir i svaret vil være det fulle restbeløpet på lånet,
+inkludert det som er sikret i foreldrense eiendom. Låntakere som ikker er hjemmelshaver vil være tom da foreldrene ikke er låntaker, feltet for realkausjon vil være false da selgende eiendom ikke 
+er brukt som sikring for noen andre enn hjemmelshavers lån.
+
+## Barna selger og foreldre er låntakere
+
+Når foreldrene også er låntakere, vil navn på foreldrene stå i listen over låntakere som ikke er hjemmelshaver i eiendom som selges. Feltet realkausejon vil være `false`. Lånet vil være oppgitt og
+koblet mot pantedokumentet.
+
+
+


### PR DESCRIPTION
Flagget for erRealkausjon flyttes slik at det ikke oppgis per lån i svaret, men én gang per besvarelse (slik som er sperret for opplåning).