### PR TITLE
fix: fiks if-test for seksjonsnummer/festenummer

### DIFF
--- a/spesifikasjoner/afpant/afpant-model/xslt/dsve.xslt
+++ b/spesifikasjoner/afpant/afpant-model/xslt/dsve.xslt
@@ -842,12 +842,17 @@
       <xsl:value-of select="$matrikkel/@gaardsnummer"/>
       <xsl:text>,&#x20;bruksnr.:&#x20;</xsl:text>
       <xsl:value-of select="$matrikkel/@bruksnummer"/>
-      <!-- Siden XSD sier at seksjonsnummer / festenummer er optional tester vi også mot tom streng (PH) -->
-      <xsl:if test="not($matrikkel/@seksjonsnummer = '0') and not($matrikkel/@seksjonsnummer = '')">
+      <!--
+      Seksjonsnummer/festenummer er ikke påkrevd i XSD-en, så vi må sjekke at
+      vi har fått noe overhodet, samt at dette noe er et tall.
+      I tillegg betyr 0 "intet seksjonsnummer/festenummer",
+      så vi viser ingenting i det tilfellet heller.
+      !-->
+      <xsl:if test="number($matrikkel/@seksjonsnummer) > 0">
         <xsl:text>,&#x20;seksjonsnr.:&#x20;</xsl:text>
         <xsl:value-of select="$matrikkel/@seksjonsnummer"/>
       </xsl:if>
-      <xsl:if test="not($matrikkel/@festenummer = '0') and not($matrikkel/@festenummer = '')">
+      <xsl:if test="number($matrikkel/@festenummer) > 0">
         <xsl:text>,&#x20;festenr.:&#x20;</xsl:text>
         <xsl:value-of select="$matrikkel/@festenummer"/>
       </xsl:if>


### PR DESCRIPTION
Den eksisterende testen brukte sjekk mot tom streng for å håndtere manglende seksjonsnummer/festenummer; det holder ikke, noe som fører til at seksjonsnummer/festenummer alltid rendres, uavhengig om de er satt eller ei.

Fiks ved å erstatte hele testen med `number() > 0`, som gjør samme nytten. Om folk synes at det er skummelt å bruke `number()`, kan vi ev. gå for en forlengelse av nåværende test som sjekker at attributtet er satt, e.g. `if test="$matrikkel/@seksjonsnummer and not($matrikkel/@seksjonsnummer = '0') and not($matrikkel/@seksjonsnummer = '')`. Personlig synes jeg det blir noe voldsomt, men smaken ≈ baken, som kjent.

(Litt på si: jeg undrer på hvorfor gårdsnummer, bruksnummer, festenummer og seksjonsnummer er definert som `xs:string` i skjemaet. Ville ikke det naturlige valget vært `xs:nonNegativeInteger`?)

## Visuelle endringer

Gitt følgende registerenhet (seksjonert eiendom uten oppgitt festenummer):

```xml
<registerenhet>
    <matrikkel kommunenavn="OSLO" kommunenummer="0301" gaardsnummer="212" bruksnummer="650"
        seksjonsnummer="7" eiendomsnivaa="E"></matrikkel>
</registerenhet>
```

## Før

<img width="586" height="81" alt="image" src="https://github.com/user-attachments/assets/2abb902e-35bb-4532-b393-bf0dd9a23ff3" />

## Etter

<img width="507" height="82" alt="image" src="https://github.com/user-attachments/assets/ee7708d9-57b3-4644-9e96-ee2e305a11c5" />
