### PR TITLE
fix: forutsetningsbrev-eksempler skal kun ha ett Prioritet-element og ikke inkludere `<BeloepGjelder>`

### DIFF
--- a/spesifikasjoner/afpant/afpant-kjøperspantedokument/afpant-forutsetningsbrev/afpant-forutsetningsbrev-eksempel.xml
+++ b/spesifikasjoner/afpant/afpant-kjøperspantedokument/afpant-forutsetningsbrev/afpant-forutsetningsbrev-eksempel.xml
@@ -58,7 +58,6 @@
     <KID>10001000222111</KID>
     <KreditorSaksnummer>Lånesak 124-221/22</KreditorSaksnummer>
     <MeglerSaksnummer>117-00-1002 Lånegaten 15 B</MeglerSaksnummer>
-    <BeloepGjelder>dekning av kjøpesum for ovennevnte eiendom</BeloepGjelder>
     <ProdusertDato>2019-01-25T10:15:23.2962746+01:00</ProdusertDato>
   </OverfoerselDetaljer>
   <Avsender>

--- a/spesifikasjoner/afpant/afpant-kjøperspantedokument/afpant-forutsetningsbrev/afpant-forutsetningsbrev-eksempel.xml
+++ b/spesifikasjoner/afpant/afpant-kjøperspantedokument/afpant-forutsetningsbrev/afpant-forutsetningsbrev-eksempel.xml
@@ -28,26 +28,24 @@
     <Beloep>251230</Beloep>
     <ForstePrioritet>false</ForstePrioritet>
     <Prioritet>
-            <PrioritetsAngivelse>
-            <Rekkefolge>PrioritetEtter</Rekkefolge>
-            <Panthaver>
-                <Nummer>987412548</Nummer>
-                <Navn>Husbanken</Navn>
-            </Panthaver>
-            <Beloep>1250000</Beloep>
-            <PrioritetsBeskrivelse>Tekst av noe slag</PrioritetsBeskrivelse>
-            </PrioritetsAngivelse>
-    </Prioritet>
-    <Prioritet>
-            <PrioritetsAngivelse>
-            <Rekkefolge>PrioritetLikestiltMed</Rekkefolge>
-            <Panthaver>
-                <Nummer>921345687</Nummer>
-                <Navn>Sparebanken Vest</Navn>
-            </Panthaver>
-            <Beloep>2000000</Beloep>
-            <PrioritetsBeskrivelse>Bank til annet familie medlem</PrioritetsBeskrivelse>
-            </PrioritetsAngivelse>
+      <PrioritetsAngivelse>
+        <Rekkefolge>PrioritetEtter</Rekkefolge>
+        <Panthaver>
+          <Nummer>987412548</Nummer>
+          <Navn>Husbanken</Navn>
+        </Panthaver>
+        <Beloep>1250000</Beloep>
+        <PrioritetsBeskrivelse>Tekst av noe slag</PrioritetsBeskrivelse>
+      </PrioritetsAngivelse>
+      <PrioritetsAngivelse>
+        <Rekkefolge>PrioritetLikestiltMed</Rekkefolge>
+        <Panthaver>
+          <Nummer>921345687</Nummer>
+          <Navn>Sparebanken Vest</Navn>
+        </Panthaver>
+        <Beloep>2000000</Beloep>
+        <PrioritetsBeskrivelse>Bank til annet familie medlem</PrioritetsBeskrivelse>
+      </PrioritetsAngivelse>
     </Prioritet>
   </PantedokumentDetaljer>
   <OverfoerselDetaljer>

--- a/spesifikasjoner/afpant/afpant-kjøperspantedokument/afpant-forutsetningsbrev/afpant-forutsetningsbrev-eksempel.xml
+++ b/spesifikasjoner/afpant/afpant-kjøperspantedokument/afpant-forutsetningsbrev/afpant-forutsetningsbrev-eksempel.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0"?>
 <?xml-stylesheet type="text/xsl" href="https://prod.cdn.dsop.no/dsve/v/2.0.0/xslt/afpant-forutsetningsbrev.xslt"?>
-<Forutsetningsbrev xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<Forutsetningsbrev xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xsi:noNamespaceSchemaLocation="./afpant-forutsetningsbrev.xsd">
   <Kreditor>
     <Nummer>123456789</Nummer>
     <Navn>TietoEVRY Banken, filial Fornebu</Navn>

--- a/spesifikasjoner/afpant/afpant-kjøperspantedokument/afpant-forutsetningsbrev/afpant-forutsetningsbrev-eksempel_betalingsmelding.xml
+++ b/spesifikasjoner/afpant/afpant-kjøperspantedokument/afpant-forutsetningsbrev/afpant-forutsetningsbrev-eksempel_betalingsmelding.xml
@@ -28,26 +28,24 @@
     <Beloep>251230</Beloep>
     <ForstePrioritet>false</ForstePrioritet>
     <Prioritet>
-            <PrioritetsAngivelse>
-            <Rekkefolge>PrioritetEtter</Rekkefolge>
-            <Panthaver>
-                <Nummer>987412548</Nummer>
-                <Navn>Husbanken</Navn>
-            </Panthaver>
-            <Beloep>1250000</Beloep>
-            <PrioritetsBeskrivelse>Tekst av noe slag</PrioritetsBeskrivelse>
-            </PrioritetsAngivelse>
-    </Prioritet>
-    <Prioritet>
-            <PrioritetsAngivelse>
-            <Rekkefolge>PrioritetLikestiltMed</Rekkefolge>
-            <Panthaver>
-                <Nummer>921345687</Nummer>
-                <Navn>Sparebanken Vest</Navn>
-            </Panthaver>
-            <Beloep>2000000</Beloep>
-            <PrioritetsBeskrivelse>Bank til annet familie medlem</PrioritetsBeskrivelse>
-            </PrioritetsAngivelse>
+      <PrioritetsAngivelse>
+        <Rekkefolge>PrioritetEtter</Rekkefolge>
+        <Panthaver>
+          <Nummer>987412548</Nummer>
+          <Navn>Husbanken</Navn>
+        </Panthaver>
+        <Beloep>1250000</Beloep>
+        <PrioritetsBeskrivelse>Tekst av noe slag</PrioritetsBeskrivelse>
+      </PrioritetsAngivelse>
+      <PrioritetsAngivelse>
+        <Rekkefolge>PrioritetLikestiltMed</Rekkefolge>
+        <Panthaver>
+          <Nummer>921345687</Nummer>
+          <Navn>Sparebanken Vest</Navn>
+        </Panthaver>
+        <Beloep>2000000</Beloep>
+        <PrioritetsBeskrivelse>Bank til annet familie medlem</PrioritetsBeskrivelse>
+      </PrioritetsAngivelse>
     </Prioritet>
   </PantedokumentDetaljer>
   <OverfoerselDetaljer>

--- a/spesifikasjoner/afpant/afpant-kjøperspantedokument/afpant-forutsetningsbrev/afpant-forutsetningsbrev-eksempel_betalingsmelding.xml
+++ b/spesifikasjoner/afpant/afpant-kjøperspantedokument/afpant-forutsetningsbrev/afpant-forutsetningsbrev-eksempel_betalingsmelding.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0"?>
 <?xml-stylesheet type="text/xsl" href="./afpant-forutsetningsbrev.xslt"?>
-<Forutsetningsbrev xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<Forutsetningsbrev xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xsi:noNamespaceSchemaLocation="./afpant-forutsetningsbrev.xsd">
   <Kreditor>
     <Nummer>123456789</Nummer>
     <Navn>TietoEVRY Banken, filial Fornebu</Navn>

--- a/spesifikasjoner/afpant/afpant-kjøperspantedokument/afpant-forutsetningsbrev/afpant-forutsetningsbrev-eksempel_betalingsmelding.xml
+++ b/spesifikasjoner/afpant/afpant-kjøperspantedokument/afpant-forutsetningsbrev/afpant-forutsetningsbrev-eksempel_betalingsmelding.xml
@@ -58,7 +58,6 @@
     <Betalingsmelding>Merk innbetaling med: AF123M7</Betalingsmelding>
     <KreditorSaksnummer>Lånesak 124-221/22</KreditorSaksnummer>
     <MeglerSaksnummer>117-00-1002 Lånegaten 15 B</MeglerSaksnummer>
-    <BeloepGjelder>dekning av kjøpesum for ovennevnte eiendom</BeloepGjelder>
     <ProdusertDato>2019-01-25T10:15:23.2962746+01:00</ProdusertDato>
   </OverfoerselDetaljer>
   <Avsender>


### PR DESCRIPTION
I følge XSD-en er `<Prioritet>` definert som `<xs:element minOccurs="0" maxOccurs="1" name="Prioritet" type="ArrayOfPrioritetsAngivelse">`. Altså skal det være maksimalt ett Prioritet-element, som inneholder et eller flere PrioritetsAngivelse-elementer, ikke et separat Prioritet-element for hver prioritetsangivelse.

Det hadde vært kjekt å ha CI som gjorde basic validering av eksemplene opp mot XSD-en…

I tillegg slang jeg på `xsi:noNamespaceSchemaLocation="./afpant-forutsetningsbrev.xsd"` i eksemplene, så IDE-er som støtter det faktisk validerer dem mot skjemaet. Dette førte til at jeg oppdaget at `<BeloepGjelder>` er spesifisert i begge eksemplene, til tross for at det ikke er i skjemaet (jfr. #108).

/cc @javaguruen 